### PR TITLE
comex/ofi: fixed EP initialization

### DIFF
--- a/comex/src-ofi/comex.c
+++ b/comex/src-ofi/comex.c
@@ -930,7 +930,7 @@ static int init_ofi()
         init_done = (init_ep(hints_remcon, &ofi_data.ep_rma, 1) == COMEX_SUCCESS);
         if(!init_done)
             init_done = (init_ep(hints_saw, &ofi_data.ep_rma, 1) == COMEX_SUCCESS);
-        COMEX_CHKANDJUMP(init_done, "failed to create endpoint");
+        EXPR_CHKANDJUMP(init_done, "failed to create endpoint");
 
         if(async_progress) /* when async progress used all atomics are implemented using p2p */
             ofi_data.ep_atomics = ofi_data.ep_rma;
@@ -944,7 +944,7 @@ static int init_ofi()
             init_done = (init_ep(hints_remcon, &ofi_data.ep_atomics, 0) == COMEX_SUCCESS);
             if(!init_done)
                 init_done = (init_ep(hints_saw, &ofi_data.ep_atomics, 0) == COMEX_SUCCESS);
-            COMEX_CHKANDJUMP(init_done, "failed to create endpoint");
+            EXPR_CHKANDJUMP(init_done, "failed to create endpoint");
         }
     }
 

--- a/comex/src-ofi/comex_impl.h
+++ b/comex/src-ofi/comex_impl.h
@@ -122,9 +122,10 @@ do                      \
   {                                       \
       if (unlikely(ret != COMEX_SUCCESS)) \
       {                                   \
-          err_printf("(%u) %s: " fmt,     \
+          err_printf("(%u) %s:%d: " fmt,  \
           (unsigned)getpid(),             \
-          __FUNCTION__, ##__VA_ARGS__);   \
+          __FUNCTION__, __LINE__,         \
+          ##__VA_ARGS__);                 \
           goto fn_fail;                   \
       }                                   \
   } while (0)


### PR DESCRIPTION
- fixed typo in macro in processing of status on
  End Point initialization (user COMEX_CHKANDJUMP instead
  of EXPR_CHKANDJUMP)
- bit improved error diagnostic: added source code line
  to error message

Signed-off-by: Oblomov, Sergey <sergey.oblomov@intel.com>