### PR TITLE
Fix installation of autotools if not present

### DIFF
--- a/travis/install-autotools.sh
+++ b/travis/install-autotools.sh
@@ -64,7 +64,7 @@ END
                 fi
             fi
             # refresh the path
-            export PATH=${TOP}:$PATH
+            export PATH=${TOP}/bin:$PATH
         else
             echo "${TOOL} found and is sufficiently new ($M4_VERSION_FOUND)"
         fi
@@ -97,7 +97,7 @@ END
         fi
 
         # refresh the path
-        export PATH=${TOP}:$PATH
+        export PATH=${TOP}/bin:$PATH
 
         cd ${TOP}
         TOOL=automake
@@ -127,7 +127,7 @@ END
         fi
 
         # refresh the path
-        export PATH=${TOP}:$PATH
+        export PATH=${TOP}/bin:$PATH
 
         cd ${TOP}
         TOOL=libtool
@@ -157,7 +157,7 @@ END
         fi
 
         # refresh the path
-        export PATH=${TOP}:$PATH
+        export PATH=${TOP}/bin:$PATH
 
         ;;
 esac


### PR DESCRIPTION
When running install-autotools.sh on a system without autoconf and
automake the script would build autoconf, but then fail to find it when
trying to build automake afterwards.