### PR TITLE
Moved value assignments out of assert statements.

### DIFF
--- a/armci/examples/features/aggregation/simple/simple.c
+++ b/armci/examples/features/aggregation/simple/simple.c
@@ -133,7 +133,8 @@ void destroy_array(void *ptr[])
 {
     armci_msg_barrier();
 
-    assert(!ARMCI_Free(ptr[me]));
+    int check = !ARMCI_Free(ptr[me]);
+    assert(check);
 }
 
 #define MAXELEMS      1000

--- a/armci/examples/features/aggregation/sparse_matvecmul/sparse_matvecmul.c
+++ b/armci/examples/features/aggregation/sparse_matvecmul/sparse_matvecmul.c
@@ -134,8 +134,8 @@ void create_array(void *a[], int elem_size, int ndim, int dims[])
 void destroy_array(void *ptr[])
 {
     armci_msg_barrier();
-
-    assert(!ARMCI_Free(ptr[me]));
+    int check = !ARMCI_Free(ptr[me]);
+    assert(check);
 }
 
 static void verify_list(int *proc_row_list) {

--- a/armci/examples/features/concurrency/multidma/multidma.c
+++ b/armci/examples/features/concurrency/multidma/multidma.c
@@ -370,7 +370,8 @@ int main (int argc, char *argv[])
 
     /* generate random pairs of processors */
 #define HALFSIZE    (size / 2)
-    assert(p_srcs = malloc(sizeof(int) * size));
+    p_srcs = malloc(sizeof(int) * size);
+    assert(p_srcs);
     for (i = 0; i < size; i++) p_srcs[i] = -1;
     p_dsts = p_srcs + HALFSIZE;
 
@@ -397,7 +398,8 @@ int main (int argc, char *argv[])
 
     /* allocate memory tatistics */
     l = sizeof(struct stats) + 2 * sizeof(double) * (size + SML_MSGS);
-    assert(st = malloc(l));
+    st = malloc(l);
+    assert(st);
     st->size = l;
     st->nb_put_a = (double *)(((char *)st) + sizeof(struct stats));
     st->nb_get_a = st->nb_put_a + SML_MSGS;

--- a/armci/examples/features/concurrency/simple/comdegree.c
+++ b/armci/examples/features/concurrency/simple/comdegree.c
@@ -65,7 +65,8 @@ void destroy_array(void *ptr[])
 {
     armci_msg_barrier();
 
-    assert(!ARMCI_Free(ptr[me]));
+    int check = !ARMCI_Free(ptr[me]);
+    assert(check);
 }
 
 

--- a/armci/examples/features/non-blocking/overlap/overlap.c
+++ b/armci/examples/features/non-blocking/overlap/overlap.c
@@ -654,7 +654,8 @@ int main (int argc, char *argv[])
 
     /* generate random pairs of processors */
 #define HALFSIZE    (size / 2)
-    assert(p_srcs = malloc(sizeof(int) * size));
+    p_srcs = malloc(sizeof(int) * size);
+    assert(p_srcs);
     for (i = 0; i < size; i++) p_srcs[i] = -1;
     p_dsts = p_srcs + HALFSIZE;
 
@@ -684,7 +685,8 @@ int main (int argc, char *argv[])
     /* allocate memory for statisticis */
 #define MSG_OFF (STATS_COUNT * size)
 #define OPS_OFF (MSG_OFF * MSG_COUNT)
-    assert(stats_all = malloc(OPS_COUNT * OPS_OFF * sizeof(double)));
+    stats_all = malloc(OPS_COUNT * OPS_OFF * sizeof(double));
+    assert(stats_all);
 
     for (i = 0; i < OPS_COUNT; i++)
         for (j = 0; j < MSG_COUNT; j++) {

--- a/armci/examples/features/notification/simple/testnotify.c
+++ b/armci/examples/features/notification/simple/testnotify.c
@@ -274,7 +274,8 @@ int i, rc;
 void destroy_array(void *ptr[])
 {
     armci_msg_barrier();
-    assert(!ARMCI_Free(ptr[me]));
+    int check = !ARMCI_Free(ptr[me]) ;
+    assert(check);
 }
 
 

--- a/armci/f90/armcif90.c
+++ b/armci/f90/armcif90.c
@@ -260,8 +260,10 @@ void ARMCI_Put_farrays(void* dv_src, array_slice_t* src_slc,
     return;
   }
 #if 0
-  assert(addr_src = g_save_addr);
-  assert(addr_dst = g_save_addr);
+  addr_src = g_save_addr;
+  assert(addr_src);
+  addr_dst = g_save_add;
+  assert(addr_dst);
 #endif
   /*
   ad_src = GET_ARR_DSC_FROM_ARRAY(addr_src);
@@ -434,8 +436,10 @@ ARMCI_NbPut_farrays(void* dv_src, array_slice_t* src_slc,
   }
 
 #if 0
-  assert(addr_src = g_save_addr);
-  assert(addr_dst = g_save_addr);
+  addr_src = g_save_addr;
+  assert(addr_src);
+  addr_dst = g_save_add;
+  assert(addr_dst);
 #endif
   /*
    ad_src = GET_ARR_DSC_FROM_ARRAY(addr_src);
@@ -630,8 +634,10 @@ void ARMCI_Get_farrays(void* dv_src, array_slice_t* src_slc,
     return;
   }
 #if 0
-  assert(addr_src = g_save_addr);
-  assert(addr_dst = g_save_addr);
+  addr_src = g_save_addr;
+  assert(addr_src);
+  addr_dst = g_save_add;
+  assert(addr_dst);
 #endif
 
   ad_src = GET_ARR_DSC_FROM_ARRAY(addr_src);
@@ -798,8 +804,10 @@ void ARMCI_NbGet_farrays(void* dv_src, array_slice_t* src_slc,
     return;
   }
 #if 0
-  assert(addr_src = g_save_addr);
-  assert(addr_dst = g_save_addr);
+  addr_src = g_save_addr;
+  assert(addr_src);
+  addr_dst = g_save_add;
+  assert(addr_dst);
 #endif
 
   ad_src = GET_ARR_DSC_FROM_ARRAY(addr_src);

--- a/armci/src-gemini/pendbufs.c
+++ b/armci/src-gemini/pendbufs.c
@@ -274,7 +274,8 @@ static int _armci_serv_pendbuf_can_progress(immbuf_t *vbuf) {
       return 1;
     }
 
-    assert(ARMCI_ACC(msginfo->operation));
+    int check = ARMCI_ACC(msginfo->operation);
+    assert(check);
     for(ptr=info->order_head; ptr!=NULL; ptr=ptr->order_next) {
       request_header_t *m = (request_header_t *)ptr->buf;
       assert(m->from == msginfo->from);

--- a/armci/src-portals/pendbufs.c
+++ b/armci/src-portals/pendbufs.c
@@ -274,7 +274,8 @@ static int _armci_serv_pendbuf_can_progress(immbuf_t *vbuf) {
       return 1;
     }
 
-    assert(ARMCI_ACC(msginfo->operation));
+    int check = ARMCI_ACC(msginfo->operation);
+    assert(check);
     for(ptr=info->order_head; ptr!=NULL; ptr=ptr->order_next) {
       request_header_t *m = (request_header_t *)ptr->buf;
       assert(m->from == msginfo->from);
@@ -489,7 +490,8 @@ static void _armci_serv_pendbuf_progress_putacc(pendbuf_t *pbuf) {
   void *buffer =((char *)(msginfo+1))+msginfo->dscrlen;
   int *status = &pbuf->status;  
 
-  assert(msginfo->operation==PUT || ARMCI_ACC(msginfo->operation));
+  int check =ARMCI_ACC(msginfo->operation);
+  assert(msginfo->operation==PUT || check);
   assert(sizeof(request_header_t)+msginfo->dscrlen+msginfo->datalen<PENDING_BUF_LEN);
   switch(*status) {
   case INIT:

--- a/armci/src/devices/openib/pendbufs.c
+++ b/armci/src/devices/openib/pendbufs.c
@@ -255,7 +255,8 @@ static int _can_progress_accnoorder(immbuf_t *vbuf) {
     return 1;
   }
   
-  assert(ARMCI_ACC(msginfo->operation));
+  int check = ARMCI_ACC(msginfo->operation);
+  assert(check);
   for(ptr=info->order_head; ptr!=NULL; ptr=ptr->order_next) {
     request_header_t *m = (request_header_t *)ptr->buf;
     assert(m->from == msginfo->from);

--- a/armci/testing/perf_aggr.c
+++ b/armci/testing/perf_aggr.c
@@ -147,7 +147,8 @@ void destroy_array(double *ptr[])
 {
   ARMCI_Barrier();
 
-  assert(!ARMCI_Free(ptr[me]));
+  int check = !ARMCI_Free(ptr[me]);
+  assert(check);
 }
 
 #define MAXELEMS      1000

--- a/armci/testing/perf_nb.c
+++ b/armci/testing/perf_nb.c
@@ -157,7 +157,8 @@ void destroy_array(double *ptr[])
 {
   ARMCI_Barrier();
 
-  assert(!ARMCI_Free(ptr[me]));
+  int check = !ARMCI_Free(ptr[me]);
+  assert(check);
 }
 
 void verify_results(int op, int *elems)

--- a/armci/testing/test.c
+++ b/armci/testing/test.c
@@ -418,7 +418,8 @@ void destroy_array(void *ptr[])
 {
   ARMCI_Barrier();
 #if 0
-  assert(!ARMCI_Free(ptr[me]));
+  int check = !ARMCI_Free(ptr[me]);
+  assert(check);
 #endif
 }
 
@@ -1275,7 +1276,8 @@ void test_vector_acc()
   ARMCI_Barrier();
 
   /* copy my patch into local array c */
-  assert(!ARMCI_Get((double *)b[proc], c, bytes, proc));
+  int check = !ARMCI_Get((double *)b[proc], c, bytes, proc);
+  assert(check);
 
   /*        scale = alpha*TIMES*nproc; */
   scale = alpha * TIMES * nproc * nproc;
@@ -1476,9 +1478,10 @@ void test_memlock()
       bytes = sizeof(double) * elems;
 
       armci_lockmem(pstart, pend, proc);
-      assert(!ARMCI_Put(a, pstart, bytes, proc));
-      assert(!ARMCI_Get(pstart, c, bytes, proc));
-      assert(!ARMCI_Get(pstart, c, bytes, proc));
+      int check=!ARMCI_Put(a, pstart, bytes, proc);
+      assert(check);
+      check = !ARMCI_Get(pstart, c, bytes, proc);
+      assert(check);
       armci_unlockmem();
       for (k = 0; k < elems; k++)if (a[k] != c[k]) {
           printf("%d: error patch (%d:%d) elem=%d val=%f\n", me, first, last, k, c[k]);

--- a/armci/testing/test2.c
+++ b/armci/testing/test2.c
@@ -168,7 +168,8 @@ void destroy_array(void *ptr[])
 {
   ARMCI_Barrier();
 
-  assert(!ARMCI_Free(ptr[me]));
+  int check = !ARMCI_Free(ptr[me]);
+  assert(check);
 }
 
 

--- a/armci/testing/test_groups.c
+++ b/armci/testing/test_groups.c
@@ -102,7 +102,8 @@ void destroy_array(void *ptr[])
 {
   ARMCI_Barrier();
 
-  assert(!ARMCI_Free(ptr[me]));
+  int check = !ARMCI_Free(ptr[me]);
+  assert(check);
 }
 
 #define GNUM_A 3

--- a/armci/testing/test_mt.c
+++ b/armci/testing/test_mt.c
@@ -245,8 +245,10 @@ int main(int argc, char *argv[])
   rnd_one = RND(0, th_size);
   prndbg(0, "random one = %d\n", rnd_one);
 
-  assert(ptrs1 = calloc(th_size, sizeof(void *)));
-  assert(ptrs2 = calloc(th_size, sizeof(void *)));
+  ptrs1 = calloc(th_size, sizeof(void *));
+  assert(ptrs1);
+  ptrs2 = calloc(th_size, sizeof(void *));
+  assert(ptrs2);
 #ifdef NOTHREADS
   thread_main((void *)(long)0);
 #else
@@ -283,8 +285,10 @@ void *thread_main(void *arg)
   th_idx = (int)(long)arg;
   prndbg(th_idx, "thread %d(%d|%d) STARTED\n", TH_ME, rank, th_idx);
 
-  assert(!ARMCI_MALLOC_MT(ptrs1, ASIZExITERSxTH_BYTES));
-  assert(!ARMCI_MALLOC_MT(ptrs2, ASIZExITERSxTH_BYTES));
+  int check = !ARMCI_MALLOC_MT(ptrs1, ASIZExITERSxTH_BYTES);
+  assert(check);
+  check = !ARMCI_MALLOC_MT(ptrs2, ASIZExITERSxTH_BYTES);
+  assert(check);
 #if 0
   for (i = 0, cbufl = 0; i < th_size; i++) {
     cbufl += sprintf(cbuf + cbufl, " %p", ptrs1[i]);
@@ -300,7 +304,8 @@ void *thread_main(void *arg)
   init_array(th_idx, ptrs2[TH_ME]);
 #endif
 
-  assert(rmt = calloc(th_size, sizeof(int)));
+  rmt = calloc(th_size, sizeof(int));
+  assert(rmt);
 
   PRINTF0T("  TESTING GET/PUT/ACC\n\n");
 
@@ -447,7 +452,8 @@ void test_pairs(int th_idx)
     /* src - addr of remote thread block on my proc/thread */
     dst = &AELEM(ptrs2[TH_ME], rem_th, i, 0);
     /* get from my pair */
-    assert(!ARMCI_Get(src, dst, ASIZE_BYTES, rem_proc));
+    int check = !ARMCI_Get(src, dst, ASIZE_BYTES, rem_proc);
+    assert(check);
   }
 
   MT_BARRIER();
@@ -494,8 +500,11 @@ void test_PutGetAcc(int th_idx, int tgt, int *rmt, int rmt_cnt)
     for (i = 0; i < iters; i++) {
       src = &AELEM(ptrs1[a], b, i, 0); /* a.ptrs1[b] */
       dst = &AELEM(ptrs2[b], a, i, 0); /* b.ptrs2[a] */
-      //            assert(!ARMCI_Put(src, dst, ASIZE_BYTES, b_proc));
-      assert(!ARMCI_PutS(src, stride, dst, stride, count, 1, b_proc));
+      int check;
+      // check = !ARMCI_Put(src, dst, ASIZE_BYTES, b_proc);
+      //      assert(check);
+      check = !ARMCI_PutS(src, stride, dst, stride, count, 1, b_proc);
+      assert(check);
     }
     ARMCI_Fence(b_proc);
   }
@@ -524,7 +533,8 @@ void test_PutGetAcc(int th_idx, int tgt, int *rmt, int rmt_cnt)
     for (i = 0; i < iters; i++) {
       src = &AELEM(ptrs1[b], a, i, 0); /* b.ptrs1[a] */
       dst = &AELEM(ptrs2[a], b, i, 0); /* a.ptrs2[b] */
-      assert(!ARMCI_GetS(src, stride, dst, stride, count, 1, b_proc));
+      check = !ARMCI_GetS(src, stride, dst, stride, count, 1, b_proc);
+      assert(check);
     }
   }
   print_array(th_idx, "GET:ptrs1[TH_ME]", ptrs1[TH_ME]);
@@ -549,7 +559,8 @@ void test_PutGetAcc(int th_idx, int tgt, int *rmt, int rmt_cnt)
     for (i = 0; i < iters; i++) {
       src = &AELEM(ptrs1[a], b, i, 0); /* a.ptrs1[b] */
       dst = &AELEM(ptrs2[b], a, i, 0); /* b.ptrs2[a] */
-      assert(!ARMCI_AccS(ARMCI_ACC_DBL, &scale, src, stride, dst, stride, count, 1, b_proc));
+      check = !ARMCI_AccS(ARMCI_ACC_DBL, &scale, src, stride, dst, stride, count, 1, b_proc);
+      assert(check);
     }
     ARMCI_Fence(b_proc);
   }

--- a/armci/testing/testnotify.c
+++ b/armci/testing/testnotify.c
@@ -403,7 +403,8 @@ void destroy_array(void *ptr[])
 {
   ARMCI_Barrier();
 
-  assert(!ARMCI_Free(ptr[me]));
+  int check = !ARMCI_Free(ptr[me]);
+  assert(check);
 }
 
 


### PR DESCRIPTION
Originally, when configured --with-sockets and CPPFLAGS=-DNDEBUG, testing/test.x in armci failed. Now all armci tests pass.
