### PR TITLE
add ga_msg_sync to Fortran

### DIFF
--- a/global/src/fapi.c
+++ b/global/src/fapi.c
@@ -1461,6 +1461,16 @@ void FATR nga_sync_()
   wnga_sync();
 }
 
+void FATR ga_msg_sync_()
+{
+  wnga_msg_sync();
+}
+
+void FATR nga_msg_sync_()
+{
+  wnga_msg_sync();
+}
+
 /* Routines from global.util.c */
 
 void FATR ga_print_stats_()


### PR DESCRIPTION
Implements the Fortran API for `ga_msg_sync` as suggested by https://github.com/nwchemgit/nwchem/pull/47#issuecomment-411935223.