### PR TITLE
feature/SICM

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,8 +16,8 @@ addons:
       - coreutils
     update: true
 cache:
-  directories:
-    - $HOME/travis
+    directories:
+        - $HOME/travis
 matrix:
   allow_failures:
     - env: MPI_IMPL=openmpi
@@ -25,8 +25,6 @@ matrix:
     - osx_image: xcode9.1
     - osx_image: xcode7.3
 env:
-  - MPI_IMPL=mpich
-    PORT=mpi-pr
   # - MPI_IMPL=mpich
   #   PORT=sockets
   # - MPI_IMPL=mpich
@@ -35,6 +33,8 @@ env:
   #   PORT=mpi-mt
   # - MPI_IMPL=mpich
   #   PORT=mpi-pt
+  - MPI_IMPL=mpich
+    PORT=mpi-pr
   # - MPI_IMPL=mpich
   #   PORT=mpi3
   # - MPI_IMPL=openmpi
@@ -54,9 +54,8 @@ before_install:
 install:
   - sh ./travis/install-mpi.sh $TRAVIS_ROOT $MPI_IMPL
   - if [[ "$PORT" == "ofi" ]]; then sh ./travis/install-libfabric.sh $TRAVIS_ROOT; fi
-  - if [[ ( "$PORT" == "mpi-pr" ) && ( "$TRAVIS_OS_NAME" == "linux" ) ]]; then sh ./travis/install-sicm.sh $TRAVIS_ROOT; fi
+  - if [[ ( "$PORT" == "mpi-pr" ) && ( "$TRAVIS_OS_NAME" == "linux" ) ]]; then sh ./travis/install-sicm.sh $HOME/no_cache; fi
 script:
   - sh ./travis/build-run.sh $TRAVIS_ROOT $PORT $MPI_IMPL
 after_failure:
-  - cat config.log
   - cat ./test-suite.log

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,8 @@
 sudo: required
 language: c
 os:
-  - osx
   - linux
+  - osx
 compiler:
   - clang
   - gcc
@@ -26,27 +26,27 @@ matrix:
     - osx_image: xcode7.3
 env:
   - MPI_IMPL=mpich
-    PORT=sockets
-  - MPI_IMPL=mpich
-    PORT=mpi-ts
-  - MPI_IMPL=mpich
-    PORT=mpi-mt
-  - MPI_IMPL=mpich
-    PORT=mpi-pt
-  - MPI_IMPL=mpich
     PORT=mpi-pr
-  - MPI_IMPL=mpich
-    PORT=mpi3
-  - MPI_IMPL=openmpi
-    PORT=mpi-ts
-  - MPI_IMPL=mpich
-    PORT=mpi-ts
-    CONFIG_OPTS="--disable-f77 --enable-cxx"
-  - MPI_IMPL=mpich
-    PORT=mpi-ts
-    CONFIG_OPTS="--disable-static --enable-shared"
-  - MPI_IMPL=mpich
-    PORT=ofi
+  # - MPI_IMPL=mpich
+  #   PORT=sockets
+  # - MPI_IMPL=mpich
+  #   PORT=mpi-ts
+  # - MPI_IMPL=mpich
+  #   PORT=mpi-mt
+  # - MPI_IMPL=mpich
+  #   PORT=mpi-pt
+  # - MPI_IMPL=mpich
+  #   PORT=mpi3
+  # - MPI_IMPL=openmpi
+  #   PORT=mpi-ts
+  # - MPI_IMPL=mpich
+  #   PORT=mpi-ts
+  #   CONFIG_OPTS="--disable-f77 --enable-cxx"
+  # - MPI_IMPL=mpich
+  #   PORT=mpi-ts
+  #   CONFIG_OPTS="--disable-static --enable-shared"
+  # - MPI_IMPL=mpich
+  #   PORT=ofi
 before_install:
   - export TRAVIS_ROOT=$HOME/travis
   - mkdir -p $TRAVIS_ROOT
@@ -58,4 +58,5 @@ install:
 script:
   - sh ./travis/build-run.sh $TRAVIS_ROOT $PORT $MPI_IMPL
 after_failure:
+  - cat config.log
   - cat ./test-suite.log

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
-sudo: false
+sudo: required
 language: c
 os:
   - osx
@@ -10,6 +10,14 @@ addons:
   apt:
     packages:
       - gfortran
+  homebrew:
+    packages:
+      - gcc
+      - coreutils
+    update: true
+cache:
+  directories:
+    - $HOME/travis
 matrix:
   allow_failures:
     - env: MPI_IMPL=openmpi
@@ -41,13 +49,12 @@ env:
     PORT=ofi
 before_install:
   - export TRAVIS_ROOT=$HOME/travis
-  - mkdir $TRAVIS_ROOT
+  - mkdir -p $TRAVIS_ROOT
   - sh ./travis/install-autotools.sh $TRAVIS_ROOT
 install:
-  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew install gcc || brew upgrade gcc || true; fi
-  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew install coreutils || brew upgrade coreutils || true; fi
   - sh ./travis/install-mpi.sh $TRAVIS_ROOT $MPI_IMPL
   - if [[ "$PORT" == "ofi" ]]; then sh ./travis/install-libfabric.sh $TRAVIS_ROOT; fi
+  - if [[ ( "$PORT" == "mpi-pr" ) && ( "$TRAVIS_OS_NAME" == "linux" ) ]]; then sh ./travis/install-sicm.sh $TRAVIS_ROOT; fi
 script:
   - sh ./travis/build-run.sh $TRAVIS_ROOT $PORT $MPI_IMPL
 after_failure:

--- a/comex/src-mpi-pr/comex.c
+++ b/comex/src-mpi-pr/comex.c
@@ -675,6 +675,10 @@ int comex_finalize()
     fprintf(stderr, "[%d] after comex_group_finalize()\n", g_state.rank);
 #endif
 
+#if USE_SICM
+    sicm_fini();
+#endif
+
 #if DEBUG_TO_FILE
     fclose(comex_trace_file);
 #endif
@@ -694,7 +698,6 @@ void comex_error(char *msg, int code)
 #endif
     fprintf(stderr,"[%d] Received an Error in Communication: (%d) %s\n",
             g_state.rank, code, msg);
-
     MPI_Abort(g_state.comm, code);
 }
 

--- a/comex/src-mpi-pr/comex.c
+++ b/comex/src-mpi-pr/comex.c
@@ -20,6 +20,9 @@
 
 /* 3rd party headers */
 #include <mpi.h>
+#if USE_SICM
+#include <sicm_low.h>
+#endif
 
 /* our headers */
 #include "comex.h"
@@ -173,6 +176,11 @@ static int COMEX_ENABLE_PUT_IOV = ENABLE_PUT_IOV;
 static int COMEX_ENABLE_GET_IOV = ENABLE_GET_IOV;
 static int COMEX_ENABLE_ACC_IOV = ENABLE_ACC_IOV;
 
+#if USE_SICM
+static sicm_device_list devices = {0};
+static sicm_device *device = NULL;
+#endif
+
 #if PAUSE_ON_ERROR
 static int AR_caught_sig=0;
 static int AR_caught_sigsegv=0;
@@ -303,7 +311,11 @@ STATIC void _malloc_semaphore(void);
 STATIC void _free_semaphore(void);
 STATIC void* _shm_create(const char *name, size_t size);
 STATIC void* _shm_attach(const char *name, size_t size);
+#if USE_SICM
+STATIC void* _shm_map(int fd, size_t size, sicm_arena arena);
+#else
 STATIC void* _shm_map(int fd, size_t size);
+#endif
 STATIC int _set_affinity(int cpu);
 STATIC void translate_mpi_error(int ierr, const char* location);
 STATIC void strided_to_subarray_dtype(int *stride_array, int *count, int levels, MPI_Datatype base_type, MPI_Datatype *type);
@@ -314,7 +326,7 @@ int comex_init()
     int status = 0;
     int init_flag = 0;
     int i = 0;
-    
+
     if (initialized) {
         return 0;
     }
@@ -324,7 +336,7 @@ int comex_init()
     status = MPI_Initialized(&init_flag);
     CHECK_MPI_RETVAL(status);
     assert(init_flag);
-    
+
     /*MPI_Errhandler_set(MPI_COMM_WORLD, MPI_ERRORS_RETURN);*/
 
     /* groups */
@@ -507,6 +519,17 @@ int comex_init()
     nb_count_recv = 0;
     nb_count_recv_processed = 0;
 
+#if USE_SICM
+    devices = sicm_init();
+    device = NULL;
+    for(i = 0; i < devices.count; i++) {
+        if (devices.devices[i].tag == SICM_DRAM) {
+            device = &devices.devices[i];
+            break;
+        }
+    }
+#endif
+
     /* reg_cache */
     /* note: every process needs a reg cache and it's always based on the
      * world rank and size */
@@ -569,15 +592,15 @@ int comex_init_args(int *argc, char ***argv)
 {
     int init_flag;
     int status;
-    
+
     status = MPI_Initialized(&init_flag);
     CHECK_MPI_RETVAL(status);
-    
+
     if(!init_flag) {
         status = MPI_Init(argc, argv);
         CHECK_MPI_RETVAL(status);
     }
-    
+
     return comex_init();
 }
 
@@ -613,7 +636,7 @@ int comex_finalize()
 
     /* Make sure that all outstanding operations are done */
     comex_wait_all(COMEX_GROUP_WORLD);
-    
+
     comex_barrier(COMEX_GROUP_WORLD);
 
     /* send quit message to thread */
@@ -671,7 +694,7 @@ void comex_error(char *msg, int code)
 #endif
     fprintf(stderr,"[%d] Received an Error in Communication: (%d) %s\n",
             g_state.rank, code, msg);
-    
+
     MPI_Abort(g_state.comm, code);
 }
 
@@ -909,7 +932,7 @@ int comex_fence_all(comex_group_t group)
     fprintf(stderr, "[%d] comex_fence_all asm volatile (\"\" : : : \"memory\"); \n",
             g_state.rank, group);
 #endif
-    asm volatile ("" : : : "memory"); 
+    asm volatile ("" : : : "memory");
 #endif
 
     /* optimize by only sending to procs which we have outstanding messages */
@@ -1275,6 +1298,7 @@ STATIC reg_entry_t* _comex_malloc_local(size_t size)
     /* register the memory locally */
     reg_entry = reg_cache_insert(
             g_state.rank, memory, size, name, memory);
+
     if (NULL == reg_entry) {
         comex_error("_comex_malloc_local: reg_cache_insert", -1);
     }
@@ -1302,7 +1326,12 @@ int comex_free_local(void *ptr)
     reg_entry = reg_cache_find(g_state.rank, ptr, 0);
 
     /* unmap the memory */
+#if USE_SICM
+    sicm_free(ptr);
+    retval = 0;
+#else
     retval = munmap(ptr, reg_entry->len);
+#endif
     if (-1 == retval) {
         perror("comex_free_local: munmap");
         comex_error("comex_free_local: munmap", retval);
@@ -1481,7 +1510,7 @@ int comex_nbacc(
 int comex_nbputs(
         void *src, int *src_stride,
         void *dst, int *dst_stride,
-        int *count, int stride_levels, 
+        int *count, int stride_levels,
         int proc, comex_group_t group,
         comex_request_t *hdl)
 {
@@ -1511,9 +1540,9 @@ int comex_nbputs(
 int comex_nbgets(
         void *src, int *src_stride,
         void *dst, int *dst_stride,
-        int *count, int stride_levels, 
+        int *count, int stride_levels,
         int proc, comex_group_t group,
-        comex_request_t *hdl) 
+        comex_request_t *hdl)
 {
     nb_t *nb = NULL;
     int world_proc = -1;
@@ -1916,7 +1945,7 @@ int comex_malloc(void *ptrs[], size_t size, comex_group_t group)
 
     /* preconditions */
     COMEX_ASSERT(ptrs);
-   
+
 #if DEBUG
     fprintf(stderr, "[%d] comex_malloc(ptrs=%p, size=%lu, group=%d)\n",
             g_state.rank, ptrs, (long unsigned)size, group);
@@ -2337,7 +2366,12 @@ int comex_free(void *ptr, comex_group_t group)
 #endif
 
             /* unmap the memory */
+#if USE_SICM
+            sicm_free(reg_entry->mapped);
+            retval = 0;
+#else
             retval = munmap(reg_entry->mapped, reg_entry->len);
+#endif
             if (-1 == retval) {
                 perror("comex_free: munmap");
                 comex_error("comex_free: munmap", retval);
@@ -2858,7 +2892,7 @@ STATIC void _get_handler(header_t *header, int proc)
 #endif
 
     COMEX_ASSERT(OP_GET == header->operation);
-    
+
     reg_entry = reg_cache_find(
             header->rank, header->remote_address, header->length);
     COMEX_ASSERT(reg_entry);
@@ -3438,7 +3472,7 @@ STATIC void _fence_handler(header_t *header, int proc)
     fprintf(stderr, "[%d] _fence_handler asm volatile (\"\" : : : \"memory\"); \n",
             g_state.rank);
 #endif
-    asm volatile ("" : : : "memory"); 
+    asm volatile ("" : : : "memory");
 #endif
 
     /* we send the ack back to the originating proc */
@@ -3471,7 +3505,7 @@ STATIC void _fetch_and_add_handler(header_t *header, char *payload, int proc)
             header->rank, header->remote_address, header->length);
     COMEX_ASSERT(reg_entry);
     mapped_offset = _get_offset_memory(reg_entry, header->remote_address);
-    
+
     if (sizeof(int) == header->length) {
         value_int = malloc(sizeof(int));
         *value_int = *((int*)mapped_offset); /* "fetch" */
@@ -3514,7 +3548,7 @@ STATIC void _swap_handler(header_t *header, char *payload, int proc)
             header->rank, header->remote_address, header->length);
     COMEX_ASSERT(reg_entry);
     mapped_offset = _get_offset_memory(reg_entry, header->remote_address);
-    
+
     if (sizeof(int) == header->length) {
         value_int = malloc(sizeof(int));
         *value_int = *((int*)mapped_offset); /* "fetch" */
@@ -3588,7 +3622,7 @@ STATIC void _lock_handler(header_t *header, int proc)
 #endif
 
     COMEX_ASSERT(0 <= id);
-    
+
     if (UNLOCKED == mutexes[rank][id]) {
         mutexes[rank][id] = proc;
         server_send(&id, sizeof(int), proc);
@@ -3630,7 +3664,7 @@ STATIC void _unlock_handler(header_t *header, int proc)
 #endif
 
     COMEX_ASSERT(0 <= id);
-    
+
     if (lq_heads[rank][id]) {
         /* a lock requester was queued */
         /* find the next lock request and update queue */
@@ -3760,7 +3794,12 @@ STATIC void _free_handler(header_t *header, char *payload, int proc)
 #endif
 
             /* unmap the memory */
+#if USE_SICM
+            sicm_free(reg_entry->mapped);
+            retval = 0;
+#else
             retval = munmap(reg_entry->mapped, reg_entry->len);
+#endif
             if (-1 == retval) {
                 perror("_free_handler: munmap");
                 comex_error("_free_handler: munmap", retval);
@@ -3939,6 +3978,13 @@ STATIC void* _shm_create(const char *name, size_t size)
         comex_error("_shm_create: shm_open", fd);
     }
 
+#if USE_SICM
+    /* the file will be used for arena allocation, so it should not be truncated here */
+    sicm_arena arena = sicm_arena_create_mmapped(0, device, fd, 0, -1, 0);
+
+    /* map into local address space */
+    mapped = _shm_map(fd, size, arena);
+#else
     /* set the size of my shared memory object */
     retval = ftruncate(fd, size);
     if (-1 == retval) {
@@ -3948,6 +3994,7 @@ STATIC void* _shm_create(const char *name, size_t size)
 
     /* map into local address space */
     mapped = _shm_map(fd, size);
+#endif
 
     /* close file descriptor */
     retval = close(fd);
@@ -3978,9 +4025,15 @@ STATIC void* _shm_attach(const char *name, size_t size)
         comex_error("_shm_attach: shm_open", -1);
     }
 
+#if USE_SICM
+    sicm_arena arena = sicm_arena_create_mmapped(0, device, fd, 0, -1, 0);
+
+    /* map into local address space */
+    mapped = _shm_map(fd, size, arena);
+#else
     /* map into local address space */
     mapped = _shm_map(fd, size);
-
+#endif
     /* close file descriptor */
     retval = close(fd);
     if (-1 == retval) {
@@ -3991,12 +4044,21 @@ STATIC void* _shm_attach(const char *name, size_t size)
     return mapped;
 }
 
+#if USE_SICM
+STATIC void* _shm_map(int fd, size_t size, sicm_arena arena)
+{
+    void *memory = sicm_arena_alloc(arena, size);
+    if (NULL == memory) {
+        perror("_shm_map: mmap");
+        comex_error("_shm_map: mmap", -1);
+    }
 
+    return memory;
+}
+#else
 STATIC void* _shm_map(int fd, size_t size)
 {
-    void *memory = NULL;
-
-    memory = mmap(NULL, size, PROT_READ|PROT_WRITE, MAP_SHARED, fd, 0);
+    void *memory  = mmap(NULL, size, PROT_READ|PROT_WRITE, MAP_SHARED, fd, 0);
     if (MAP_FAILED == memory) {
         perror("_shm_map: mmap");
         comex_error("_shm_map: mmap", -1);
@@ -4004,7 +4066,7 @@ STATIC void* _shm_map(int fd, size_t size)
 
     return memory;
 }
-
+#endif
 
 STATIC int _set_affinity(int cpu)
 {
@@ -4927,7 +4989,7 @@ STATIC void nb_puts(
                 dst_bvalue[j] = 0;
             }
         }
-        
+
         nb_put((char *)src + src_idx, (char *)dst + dst_idx,
                 count[0], proc, nb);
     }
@@ -5186,7 +5248,7 @@ STATIC void nb_gets(
         }
 
         dst_idx = 0;
-        
+
         for(j=1; j<=stride_levels; j++) {
             dst_idx += (long) dst_bvalue[j] * (long) dst_stride[j-1];
             if((i+1) % dst_bunit[j] == 0) {
@@ -5196,7 +5258,7 @@ STATIC void nb_gets(
                 dst_bvalue[j] = 0;
             }
         }
-        
+
         nb_get((char *)src + src_idx, (char *)dst + dst_idx,
                 count[0], proc, nb);
     }
@@ -5462,7 +5524,7 @@ STATIC void nb_accs(
                 dst_bvalue[j] = 0;
             }
         }
-        
+
         nb_acc(datatype, scale, (char *)src + src_idx, (char *)dst + dst_idx,
                 count[0], proc, nb);
     }
@@ -6062,4 +6124,3 @@ STATIC void strided_to_subarray_dtype(int *stride_array, int *count, int levels,
         translate_mpi_error(ierr,"strided_to_subarray_dtype:MPI_Type_create_subarray");
     }
 }
-

--- a/global/testing/test.F
+++ b/global/testing/test.F
@@ -1,8 +1,8 @@
-#if HAVE_CONFIG_H 
+#if HAVE_CONFIG_H
 #   include "config.fh"
 #endif
 c $Id: test.F,v 1.64.2.11 2007-04-06 22:37:35 d3g293 Exp $
-c vector boxes lack arithmetic precision 
+c vector boxes lack arithmetic precision
 #if defined(FUJITSU)
 # define THRESH 1d-12
 # define THRESHF 1e-5
@@ -12,7 +12,7 @@ c vector boxes lack arithmetic precision
 #endif
 
 #define MISMATCH(x,y) abs(x-y)/max(1d0,abs(x)).gt.THRESH
-#define MISMATCHF(x,y) abs(x-y)/max(1.0,abs(x)).gt.THRESHF 
+#define MISMATCHF(x,y) abs(x-y)/max(1.0,abs(x)).gt.THRESHF
 
 c#define NEW_API
 c#define MIRROR
@@ -51,7 +51,7 @@ c#define USE_RESTRICTED
       integer version, subversion, patch
       logical status
       parameter (heap=800*800*4, fudge=100, stack=800*800)
-c     
+c
 c***  Intitialize a message passing library
 c
 #include "mp3.fh"
@@ -67,7 +67,7 @@ c
       me = ga_nodeid()
 c     we can also use GA_set_memory_limit BEFORE first ga_create call
 c
-      ma_heap = heap/nproc + fudge 
+      ma_heap = heap/nproc + fudge
       ma_heap = 2*ma_heap
 #ifdef USE_RESTRICTED
       ma_heap = 2*ma_heap
@@ -91,7 +91,7 @@ c***  Initialize the MA package
 c     MA must be initialized before any global array is allocated
 c
       status = ma_init(MT_DCPL, stack, ma_heap)
-      if (.not. status) call ga_error('ma_init failed',-1) 
+      if (.not. status) call ga_error('ma_init failed',-1)
 c
 c     Uncomment the below line to register external memory allocator
 c     for dynamic arrays inside GA routines.
@@ -101,7 +101,7 @@ c
         print *, 'using ', nproc,' process(es) ', ga_cluster_nnodes(),
      $           ' cluster nodes'
         print *,'process ', me, ' is on node ',ga_cluster_nodeid(),
-     $          ' with ',  ga_cluster_nprocs(-1), ' processes' 
+     $          ' with ',  ga_cluster_nprocs(-1), ' processes'
         call ffflush(6)
       endif
 c
@@ -184,9 +184,9 @@ c
          write(6,*)
          call ffflush(6)
       endif
- 
-      call check_flt() 
-c     
+
+      call check_flt()
+c
       if (me.eq.0) then
          write(6,*)
          write(6,*)'CHECKING Wrappers to Message Passing Collective ops'
@@ -196,14 +196,14 @@ c
 
       call check_wrappers
 c
-c***  Check if memory limits are enforced 
+c***  Check if memory limits are enforced
 c
       call check_mem(util_mdtob(ma_heap*ga_nnodes()))
 c
 #endif
       if(me.eq.0) call ga_print_stats()
-      if(me.eq.0) print *,' ' 
-      if(me.eq.0) print *,'All tests successful ' 
+      if(me.eq.0) print *,' '
+      if(me.eq.0) print *,'All tests successful '
       status = ga_destroy(g_s)
 c
 c***  Tidy up the GA package
@@ -222,7 +222,7 @@ c
 #include "mafdecls.fh"
 #include "global.fh"
 #include "testutil.fh"
-c     
+c
       integer n,m
       parameter (n = 256)
       parameter (m = 2*n)
@@ -261,7 +261,7 @@ c
 #endif
       intrinsic int
       iran(i) = int(drand(0)*real(i)) + 1
-c     
+c
       nproc = ga_nnodes()
       me    = ga_nodeid()
       inode = ga_cluster_nodeid()
@@ -286,7 +286,7 @@ c
       proc_grid(2) = nproc/2
 #endif
 #endif
-c     
+c
 c     a() is a local copy of what the global array should start as
 c
       do j = 1, n
@@ -296,7 +296,7 @@ c
 #else
             a(i,j) = inode + i-1 + (j-1)*n
 #endif
-            b(i,j) =-1. 
+            b(i,j) =-1.
          enddo
       enddo
 *      write(6,*) ' correct '
@@ -365,11 +365,11 @@ c
       call ga_distribution(g_a, lproc, ilo, ihi, jlo, jhi)
 #endif
       call ga_sync()
-c     
+c
 c     Zero the array
 c
-      if (me .eq. 0) then 
-         write(6,21) 
+      if (me .eq. 0) then
+         write(6,21)
  21      format('> Checking zero ... ')
          call ffflush(6)
       endif
@@ -378,8 +378,8 @@ c
 c
 c     Check that it is indeed zero
 c
-      
-      
+
+
       call ga_get(g_a, 1, n, 1, n, b, n)
       call ga_sync()
       do i = 1, n
@@ -401,7 +401,7 @@ c
 c     Each node fills in disjoint sections of the array
 c
       if (me .eq. 0) then
-         write(6,2) 
+         write(6,2)
  2       format('> Checking disjoint put ... ')
          call ffflush(6)
       endif
@@ -443,7 +443,7 @@ c
             if (b(i,j) .ne. a(i,j)) then
                write(6,*) ' put ', me, i, j, a(i,j),b(i,j)
                call ffflush(6)
-               call ga_error('... exiting ',-1)
+               call ga_error('... exiting3 ',-1)
             endif
          enddo
       enddo
@@ -483,7 +483,7 @@ c
          endif
 c
          nwords = nwords + (ihi-ilo+1)*(jhi-jlo+1)
-c     
+c
          call util_dfill(n*n, 0.0d0, b, 1)
          call ga_get(g_a, ilo, ihi, jlo, jhi, b(ilo, jlo), n)
          if (me .eq. 0 .and. mod(loop-1, max(1,nloop/20)).eq.0) then
@@ -517,17 +517,17 @@ c     Each node accumulates into disjoint sections of the array
 c
 #if 1
       if (me .eq. 0) then
-         write(6,9) 
+         write(6,9)
  9       format('> Checking accumulate ... ')
          call ffflush(6)
       endif
       call ga_sync()
-c     
+c
       crap = drand(12345)       ! Same seed for each process
       do j = 1, n
          do i = 1, n
 c           b(i,j) = drand(0)
-            b(i,j) = i+j 
+            b(i,j) = i+j
          enddo
       enddo
 c
@@ -557,7 +557,7 @@ c               print *, me, 'checking accumulate ',ilo,ihi,jlo,jhi,x
                call ga_acc(g_a, ilo, ihi, jlo, jhi, b(ilo, jlo), n, x)
             endif
             ij = ij + 1
-c     
+c
 c           Each process applies all updates to its local copy
 c
             do jj = jlo, jhi
@@ -663,7 +663,7 @@ c
             a(i,j) = 0.1d0*a(i,j) + 0.9d0*b(i,j)
          enddo
       enddo
-      
+
 #ifndef MIRROR
       if (me.eq.0) call ga_put(g_b, 1, n, 1, n, b, n)
 #else
@@ -676,7 +676,7 @@ c
             if(MISMATCH(b(i,j), a(i,j)))then
                write(6,*) ' add ', me, i, j, a(i,j), b(i,j)
                call ffflush(6)
-               call ga_error('... exiting ',-1) 
+               call ga_error('... exiting ',-1)
             endif
          enddo
       enddo
@@ -690,7 +690,7 @@ c
 c     Check the ddot function
 c
       if (me .eq. 0) then
-         write(6,19) 
+         write(6,19)
  19      format('> Checking ddot ...')
          call ffflush(6)
       endif
@@ -703,9 +703,9 @@ c
          enddo
       enddo
 #ifndef MIRROR
-      if (me.eq.0) then 
+      if (me.eq.0) then
 #else
-      if (iproc.eq.0) then 
+      if (iproc.eq.0) then
 #endif
          call ga_put(g_b, 1, n, 1, n, b, n)
          call ga_put(g_a, 1, n, 1, n, a, n)
@@ -781,7 +781,7 @@ c
       call ga_sync()
 c
       crap = drand(ga_nodeid()*51 +1) !Different seed for each proc
-      do j = 1, 10 
+      do j = 1, 10
        call ga_sync()
 #ifndef MIRROR
        itmp = iran(nproc)-1
@@ -791,12 +791,12 @@ c
        if(me.eq.itmp) then
 #endif
 #ifndef NGA_GATSCAT
-         do loop = 1,m 
-           ilo = iran(n) 
+         do loop = 1,m
+           ilo = iran(n)
            jlo = iran(n)
            iv(loop) = ilo
            jv(loop) = jlo
-         enddo 
+         enddo
          call ga_gather(g_a, v, iv, jv, m)
          do loop = 1,m
            ilo= iv(loop)
@@ -810,12 +810,12 @@ c
            endif
          enddo
 #else
-         do loop = 1,m 
-           ilo = iran(n) 
+         do loop = 1,m
+           ilo = iran(n)
            jlo = iran(n)
            ijv(1,loop) = ilo
            ijv(2,loop) = jlo
-         enddo 
+         enddo
          call nga_gather(g_a, v, ijv, m)
          do loop = 1,m
            ilo= ijv(1,loop)
@@ -839,7 +839,7 @@ c
          call ffflush(6)
       endif
 c
-      do j = 1,10 
+      do j = 1,10
        call ga_sync()
 #ifndef MIRROR
        if(me.eq.iran(ga_nnodes())-1) then
@@ -852,44 +852,44 @@ c
            jlo = iran(n)
            iv(loop) = ilo
            jv(loop) = jlo
-c          v(loop) = DSIN(a(ilo,jlo)+b(ilo,jlo)) 
+c          v(loop) = DSIN(a(ilo,jlo)+b(ilo,jlo))
            v(loop) = 1d0 *(ilo+jlo)
-         enddo 
+         enddo
          call ga_scatter(g_a, v, iv, jv, m)
          do loop = 1,m
            ilo= iv(loop)
-           jlo= jv(loop) 
+           jlo= jv(loop)
            call ga_get(g_a,ilo,ilo,jlo,jlo,w(loop),1)
-c          if(v(loop)  .ne. w(loop))then 
-           if(w(loop)  .ne. 1d0 *(ilo+jlo) )then 
-             write(6,*)me,' scatter ', ilo,',',jlo,',',w(loop) 
-     &             ,' ', 1d0 *(ilo+jlo) 
+c          if(v(loop)  .ne. w(loop))then
+           if(w(loop)  .ne. 1d0 *(ilo+jlo) )then
+             write(6,*)me,' scatter ', ilo,',',jlo,',',w(loop)
+     &             ,' ', 1d0 *(ilo+jlo)
              call ffflush(6)
              call ga_error('... exiting ',-1)
            endif
-         enddo 
+         enddo
 #else
          do loop = 1,m
            ilo = iran(n)
            jlo = iran(n)
            ijv(1,loop) = ilo
            ijv(2,loop) = jlo
-c          v(loop) = DSIN(a(ilo,jlo)+b(ilo,jlo)) 
+c          v(loop) = DSIN(a(ilo,jlo)+b(ilo,jlo))
            v(loop) = 1d0 *(ilo+jlo)
-         enddo 
+         enddo
          call nga_scatter(g_a, v, ijv, m)
          do loop = 1,m
            ilo= ijv(1,loop)
-           jlo= ijv(2,loop) 
+           jlo= ijv(2,loop)
            call ga_get(g_a,ilo,ilo,jlo,jlo,w(loop),1)
-c          if(v(loop)  .ne. w(loop))then 
-           if(w(loop)  .ne. 1d0 *(ilo+jlo) )then 
+c          if(v(loop)  .ne. w(loop))then
+           if(w(loop)  .ne. 1d0 *(ilo+jlo) )then
              write(6,927)me,ilo,jlo,w(loop),1d0 *(ilo+jlo),loop
   927        format(i3,' scatter ',i5,',',i5,',',f7.1,',',f7.1,',',i5)
              call ffflush(6)
              call ga_error('... exiting ',-1)
            endif
-         enddo 
+         enddo
 #endif
        endif
        call ga_sync()
@@ -924,9 +924,9 @@ c
 c
       x = .1d0
       ii =n
-      do jj = 1,1 
+      do jj = 1,1
         call ga_sync()
-        do loop = 1, ii 
+        do loop = 1, ii
 
 c         generate unique i,j pairs
 10        continue
@@ -957,7 +957,7 @@ c         if (found(i,j, iv, jv, loop-1) ) goto 10
 
 c
         call ga_sync()
-c     
+c
 c       check the result
 c
         call ga_get(g_a, 1, n, 1,n, a, n)
@@ -971,13 +971,13 @@ c
           j = ijv(2,loop)
 #endif
           if(MISMATCH(a(i,j),b(i,j)))then
-             print *,'Error',i,j,loop,a(i,j),'expected=',b(i,j)  
+             print *,'Error',i,j,loop,a(i,j),'expected=',b(i,j)
 *            if(me.eq.0)then
 *              do ii=1,loop
 *                   print *,'element',ii, iv(ii),jv(ii)
 *              enddo
 *            endif
-             call ga_error('scatter-acc error in trial ',jj) 
+             call ga_error('scatter-acc error in trial ',jj)
           endif
         enddo
         call ga_sync()
@@ -1002,11 +1002,11 @@ c
          enddo
       enddo
       if (me .eq. 0) then
-         write(6,23) 
+         write(6,23)
  23      format('> Checking merge ...')
          call ffflush(6)
       endif
-      if (iproc.eq.0) then 
+      if (iproc.eq.0) then
          call ga_put(g_a, 1, n, 1, n, a, n)
       endif
       call ga_merge_mirrored(g_a)
@@ -1037,7 +1037,7 @@ c
 c    Checking copy between different array configurations
 c
       if (me .eq. 0) then
-         write(6,20) 
+         write(6,20)
  20      format('> Checking mixed copy ...')
          call ffflush(6)
       endif
@@ -1112,7 +1112,7 @@ c
          enddo
       enddo
       if (me .eq. 0) then
-         write(6,24) 
+         write(6,24)
  24      format('> Checking merge to distributed patch ...')
          call ffflush(6)
       endif
@@ -1127,7 +1127,7 @@ c
        ahi(i) = ihi
        bhi(i) = ihi + 1
       end do
-      if (iproc.eq.0) then 
+      if (iproc.eq.0) then
          call ga_put(g_a, 1, n, 1, n, a, n)
       endif
       call nga_merge_distr_patch(g_a, alo, ahi, g_c, blo, bhi)
@@ -1165,7 +1165,7 @@ c     Delete the global arrays
 c
       status = ga_destroy(g_b)
       status = ga_destroy(g_a)
-c     
+c
       end
 
 c-----------------------------------------------------------------
@@ -1457,7 +1457,7 @@ c
 c           x = cmplx(drand(0),0.333d0)
 c           x = cmplx(0.333d0,0)
 *           x = cmplx(0d0,0d0)
-            x = 0 
+            x = 0
             ilo = i
             ihi = min(i+inc-1, n)
             if(ihi.eq.n-1)ihi=n
@@ -2076,7 +2076,7 @@ c
 c           x = cmplx(drand(0),0.333d0)
 c           x = cmplx(0.333d0,0)
 *           x = cmplx(0d0,0d0)
-            x = 0 
+            x = 0
             ilo = i
             ihi = min(i+inc-1, n)
             if(ihi.eq.n-1)ihi=n
@@ -2377,7 +2377,7 @@ c-----------------------------------------------------------------
 #include "mafdecls.fh"
 #include "global.fh"
 #include "testutil.fh"
-c     
+c
       integer n
       parameter (n = 128)
       integer a(n,n), b(n,n)
@@ -2406,7 +2406,7 @@ c
 #endif
       intrinsic int
       iran(i) = int(drand(0)*real(i)) + 1
-c     
+c
       nproc = ga_nnodes()
       me    = ga_nodeid()
       inode = ga_cluster_nodeid()
@@ -2430,7 +2430,7 @@ c
       proc_grid(2) = nproc/2
 #endif
 #endif
-c     
+c
 c     a() is a local copy of what the global array should start as
 c
       do j = 1, n
@@ -2442,7 +2442,7 @@ c
 #endif
          enddo
       enddo
-c     
+c
 c     Create a global array
 c
       ndim = 2
@@ -2486,11 +2486,11 @@ c
          call ffflush(6)
          call ga_error('... exiting ',-1)
       endif
-c     
+c
 c     Zero the array
 c
       if (me .eq. 0) then
-         write(6,21) 
+         write(6,21)
  21      format('> Checking zero ... ')
          call ffflush(6)
       endif
@@ -2518,7 +2518,7 @@ c
 c     Each node fills in disjoint sections of the array
 c
       if (me .eq. 0) then
-         write(6,2) 
+         write(6,2)
  2       format('> Checking disjoint put ... ')
          call ffflush(6)
       endif
@@ -2600,7 +2600,7 @@ c
             jhi = jlo
             jlo = itmp
          endif
-c     
+c
          nwords = nwords + (ihi-ilo+1)*(jhi-jlo+1)
 c
          call util_ifill(n*n, 0.0d0, b, 1)
@@ -2635,9 +2635,9 @@ c
       if (me .eq. 0 .and. n.gt.7) then
          write(6,*)
          write(6,*) '> Checking ga_print_patch --- should see '
-         write(6,*)' [2002 3002 4002 5002 6002]'  
-         write(6,*)' [2003 3003 4003 5003 6003]'  
-         write(6,*)' [2004 3004 4004 5004 6004]'  
+         write(6,*)' [2002 3002 4002 5002 6002]'
+         write(6,*)' [2003 3003 4003 5003 6003]'
+         write(6,*)' [2004 3004 4004 5004 6004]'
          write(6,*)
          call ffflush(6)
       endif
@@ -2655,7 +2655,7 @@ c
       call ga_sync()
 c
       crap = drand(ga_nodeid()*51 +1) !Different seed for each proc
-      inc =5 
+      inc =5
 c     every processor will be operating on somebody elses data
 c
 #ifndef MIRROR
@@ -2679,7 +2679,7 @@ c     write(6,111) me,ilo,ihi,jlo,jhi,dimi,dimj
   111 format(i2,'..',4i8,'.',2i8)
       call ga_sync()
       if(ilo .gt.0 .and. jhi .gt. 0)then
-       do loop = 1,nloop 
+       do loop = 1,nloop
          ii= IABS(iran(dimi)) - 1
          jj= IABS(iran(dimj)) - 1
          i=ilo + Mod(ii,dimi)
@@ -2688,16 +2688,16 @@ c
 c        write(6,*) me,'..',ilo,ihi,jlo,jhi,'.',dimi,dimj,'..',i,j
 c        call ffflush(6)
          buf = ga_read_inc(g_a,i,j,inc)
-         if(a(i,j).ne. buf)then   
+         if(a(i,j).ne. buf)then
             write(6,114) me,ilo,ihi,jlo,jhi
             write(6,112) me,i,j,a(i,j),buf,loop
-c            write(6,*)me,'READ_inc ', i,',',j,',', a(i,j),' ',buf,me 
+c            write(6,*)me,'READ_inc ', i,',',j,',', a(i,j),' ',buf,me
             call ffflush(6)
          endif
   112    format(i3,' READ_inc ',i3,',',i3,',',i8,' ',i8,' loop ',i8)
-         call ga_get(g_a, i,i,j,j, buf,1) 
-         a(i,j) = a(i,j)+inc 
-         if(a(i,j).ne.  buf)then   
+         call ga_get(g_a, i,i,j,j, buf,1)
+         a(i,j) = a(i,j)+inc
+         if(a(i,j).ne.  buf)then
             write(6,114) me,ilo,ihi,jlo,jhi
             write(6,113) me,i,j,a(i,j),buf,loop
 c            write(6,*)me,'read_INC ', i,',',j,',', a(i,j),' ',buf,me
@@ -2729,7 +2729,7 @@ c
 c
 c***  use ga_read_inc and elements g_a(1:2,1) to implement a lock
 c***  compute g_a(:,n) = sum (1(:)) for P processors
-c     
+c
       status = ga_create_mutexes(1)
       if (.not. status) then
          call ga_error('ga_create_mutexes failed ',-1)
@@ -2771,7 +2771,7 @@ c
          write(6,*)
          write(6,*) ' ga_fence and ga_lock are OK'
          write(6,*)
-      endif 
+      endif
 #endif
 c
 c
@@ -2898,11 +2898,11 @@ c
          write(6,*)
          call ffflush(6)
       endif
-c     
+c
 c     Delete the global array
 c
       status = ga_destroy(g_a)
-c     
+c
       end
 
 c---------------------------------------------------------------------
@@ -2913,7 +2913,7 @@ c---------------------------------------------------------------------
 #include "global.fh"
 #include "testutil.fh"
       integer n, m
-      parameter (n =100) 
+      parameter (n =100)
       parameter (m=2*n)
       real a(n,n), b(n,n), v(m), w(m)
       integer iv(m), jv(m)
@@ -2964,7 +2964,7 @@ c---------------------------------------------------------------------
       proc_grid(2) = nproc/2
 #endif
 #endif
-c     
+c
 c     a() is a local copy of what the global array should start as
 c
       do j = 1, n
@@ -2978,7 +2978,7 @@ c
          enddo
       enddo
 
-c     
+c
 c     Create a global array
 c
       ndim = 2
@@ -3038,13 +3038,13 @@ c
       lproc = me - ga_cluster_procid(inode,0)
       call ga_distribution(g_a, lproc, ilo, ihi, jlo, jhi)
 #endif
-      call ga_sync()      
-c     
+      call ga_sync()
+c
 c     Zero the array
 c
       if (me .eq. 0) then
-         write(6,21) 
- 21      format('> Checking zero ... ')          
+         write(6,21)
+ 21      format('> Checking zero ... ')
          call ffflush(6)
       endif
       call ga_zero(g_a)
@@ -3072,8 +3072,8 @@ c
 c     Each node fills in disjoint sections of the array
 c
       if (me .eq. 0) then
-         write(6,2) 
- 2       format('> Checking disjoint put ... ')   
+         write(6,2)
+ 2       format('> Checking disjoint put ... ')
          call ffflush(6)
       endif
       call ga_sync()
@@ -3148,7 +3148,7 @@ c
             jhi = jlo
             jlo = itmp
          endif
-c     
+c
          nwords = nwords + (ihi-ilo+1)*(jhi-jlo+1)
 c
          call util_rfill(n*n, 0.0, b, 1)
@@ -3234,7 +3234,7 @@ c
             enddo
          enddo
       enddo
-      call ga_sync()                       
+      call ga_sync()
 c
 c     All nodes check all of a
       call ga_get(g_a, 1, n, 1, n, b, n)
@@ -3294,7 +3294,7 @@ c
          write(6,91)
  91      format('> Checking add ...')
          call ffflush(6)
-      endif                           
+      endif
 c
       crap = drand(12345)       ! Everyone has same seed
       do j = 1, n
@@ -3385,7 +3385,7 @@ c
          write(6,*) ' scale is OK '
          write(6,*)
       endif
-c                                
+c
 c     Check the ga_copy function
 c
       if (me .eq. 0) then
@@ -3445,7 +3445,7 @@ c
      &             ,' ',v(loop)
              call ffflush(6)
              call ga_error('... exiting ',-1)
-           endif                                     
+           endif
          enddo
        endif
       enddo
@@ -3498,7 +3498,7 @@ c
       call ga_sync()
 c
 c     scatter-acc available in GA ver. 3.0
-#ifdef GA3                                         
+#ifdef GA3
       if (me.eq.0) then
          write(6,*)
          write(6,*) ' checking scatter-accumulate'
@@ -3519,7 +3519,7 @@ c
       do jj = 1,1
           call ga_sync()
         do loop = 1, ii
- 
+
 c          generate unique i,j pairs
 10         continue
               i = iran(n)
@@ -3535,16 +3535,16 @@ c          generate unique i,j pairs
            b(i,j) = b(i,j) + lprocs*x*v(loop) ! update local ref. array
 #endif
         enddo
- 
+
         call ga_scatter_acc(g_a,v,iv,jv, ii,x)
- 
+
 c
         call ga_sync()
 c
 c       check the result
 c
         call ga_get(g_a, 1, n, 1,n, a, n)
- 
+
         do loop = 1,ii
           i = iv(loop)
           j = jv(loop)
@@ -3557,23 +3557,23 @@ c
 *            endif
              call ga_error('scatter-acc error in trial ',jj)
           endif
-        enddo                                 
+        enddo
           call ga_sync()
- 
+
       enddo
- 
+
       call ga_sync()
       if (me.eq.0) then
          write(6,*)
          write(6,*) ' scatter-accumulate is  OK'
          write(6,*)
       endif
-#endif                      
+#endif
 c
 c     Delete the global array
 c
       status = ga_destroy(g_a)
-c     
+c
       end
 c_____________________________________________________________
 
@@ -3600,11 +3600,11 @@ c
          write(6,*)
          call ffflush(6)
       endif
-      do i = 1, n 
+      do i = 1, n
          isum(i) =  i + me
       enddo
       call ga_gop(MT_INT, isum, n, '+')
-      do i = 1, n 
+      do i = 1, n
          if(isum(i).ne.(i*nproc + (nproc-1)*nproc/2))then
             call ga_error('ga_gop error -2',isum(i))
          endif
@@ -3647,11 +3647,11 @@ c
          write(6,*)
          call ffflush(6)
       endif
-      do i = 1, n 
+      do i = 1, n
          fsum(i) = i + 1.0 * me
       enddo
       call ga_gop(MT_REAL, fsum, n, '+')
-      do i = 1, n 
+      do i = 1, n
          if(Int(fsum(i)).ne.(i*nproc + (nproc-1)*nproc/2))then
             call ga_error('ga_gop error',Int(fsum(i)))
          endif
@@ -3675,7 +3675,7 @@ c
          check(i)= cmplx(nproc*i+nproc*1d0, nproc*i+(nproc-1)*nproc/2)
       enddo
       call ga_gop(MT_DCPL, zsum, n, '+')
-      do i = 1, n 
+      do i = 1, n
          if(zsum(i).ne.check(i)) then
             call ga_error('ga_gop error', -1)
          endif
@@ -3686,7 +3686,7 @@ c
          write(6,*) ' ga_gop (double complex) is  OK'
          write(6,*)
       endif
-c                                   
+c
       call ga_sync()
       if (me .eq. 0) then
          write(6,*)
@@ -3719,7 +3719,7 @@ c
 #include "global.fh"
 #include "testutil.fh"
 c
-      integer n,nmax,left,need, me,procs,g_a, g_b 
+      integer n,nmax,left,need, me,procs,g_a, g_b
       logical status
 c
       if(.not. ga_memory_limited())return
@@ -3775,7 +3775,7 @@ c
       status = ga_destroy(g_a)
       end
 
-     
+
 
       subroutine print_mem_info(n,left, need, total)
       implicit none
@@ -3783,10 +3783,10 @@ c
 c
       write(6,*)' '
       if(left - need .ge. 0) then
-        write(6,1)n,n 
+        write(6,1)n,n
 1       format('> Creating array ',i4,' by ',i4,' -- should succeed')
       else
-        write(6,2)n,n 
+        write(6,2)n,n
 2       format('> Creating array ',i4,' by ',i4,' -- SHOULD FAIL')
       endif
       write(6,3) need, left, total
@@ -3797,18 +3797,18 @@ c
       end
 
 
-      
+
       subroutine my_lock(g_b)
       implicit none
 #include "global.fh"
       integer g_b, val, flag, i
       logical first_time
-      double precision  dummy 
-      common /lock/ val 
+      double precision  dummy
+      common /lock/ val
       common /dum/ dummy
       data first_time /.true./
 c
-c     this awkward initialization is to avoid a weird problem 
+c     this awkward initialization is to avoid a weird problem
 C     with block data on SUN
       if(first_time)then
         first_time = .false.
@@ -3817,12 +3817,12 @@ C     with block data on SUN
 c
       val = ga_read_inc(g_b,1,1, 1)
 10    call ga_get(g_b, 2,2,1,1, flag, 1)
-           if(flag.eq.val) return 
+           if(flag.eq.val) return
 c
 c          to reduce memory stress,  wait a while before retrying
            do i = 1, 100
-              dummy = dummy + .1 
-           enddo 
+              dummy = dummy + .1
+           enddo
       goto 10
       end
 
@@ -3833,7 +3833,7 @@ c          to reduce memory stress,  wait a while before retrying
       integer g_b, val
       common /lock/ val
 c
-      call ga_put(g_b, 2,2,1,1, val+1, 1) 
+      call ga_put(g_b, 2,2,1,1, val+1, 1)
       end
 
 
@@ -3851,9 +3851,9 @@ c
             enddo
 99    continue
       return
-      end 
-      
-            
+      end
+
+
       subroutine proc_remap()
       implicit none
 #include "global.fh"
@@ -3867,7 +3867,7 @@ c
 c     call ga_register_proclist(proc,nproc)
       end
 
-      
+
       subroutine util_rfill(n,val,a,ia)
       implicit none
       real  a(*), val
@@ -3887,7 +3887,7 @@ c
 c
       end
 
-      
+
       subroutine util_dfill(n,val,a,ia)
       implicit none
       double precision  a(*), val
@@ -3943,4 +3943,3 @@ c
       endif
 c
       end
-

--- a/travis/build-run.sh
+++ b/travis/build-run.sh
@@ -53,10 +53,6 @@ esac
 
 # Configure and build
 ./autogen.sh $TRAVIS_ROOT
-
-ls -R $TRAVIS_ROOT/SICM
-ls -R $TRAVIS_ROOT/jemalloc
-
 case "x$PORT" in
     xofi)
         ./configure --with-ofi=$TRAVIS_ROOT/libfabric
@@ -68,10 +64,11 @@ case "x$PORT" in
         ./configure ${CONFIG_OPTS}
         ;;
     xmpi-pr)
-        export CFLAGS="-DUSE_SICM=1 -I${TRAVIS_ROOT}/SICM/include ${CFLAGS}"
-        export LDFLAGS="-L${TRAVIS_ROOT}/jemalloc/lib -ljemalloc -L${TRAVIS_ROOT}/SICM/lib -lsicm ${LDFLAGS}"
-        export LD_LIBRARY_PATH="${TRAVIS_ROOT}/SICM/lib:${TRAVIS_ROOT}/jemalloc/lib:${LD_LIBRARY_PATH}"
-        ;&
+        export CFLAGS="-DUSE_SICM=1 -I${HOME}/no_cache/SICM/include ${CFLAGS}"
+        export LDFLAGS="-L${HOME}/no_cache/jemalloc/lib -ljemalloc -L${HOME}/no_cache/SICM/lib -lsicm ${LDFLAGS}"
+        export LD_LIBRARY_PATH="${HOME}/no_cache/SICM/lib:${HOME}/no_cache/jemalloc/lib:${LD_LIBRARY_PATH}"
+        ./configure --with-${PORT} ${CONFIG_OPTS}
+        ;;
     x*)
         ./configure --with-${PORT} ${CONFIG_OPTS}
         ;;

--- a/travis/build-run.sh
+++ b/travis/build-run.sh
@@ -52,12 +52,11 @@ case "$MPI_IMPL" in
 esac
 
 # Configure and build
-if test "x$PORT" = "xmpi-pr"
-then
-    export CFLAGS="-DUSE_SICM=1 -I${TRAVIS_ROOT}/SICM/include -L${TRAVIS_ROOT}/jemalloc/lib -ljemalloc -L${TRAVIS_ROOT}/SICM/lib -lsicm ${CFLAGS}"
-fi
-
 ./autogen.sh $TRAVIS_ROOT
+
+ls -R $TRAVIS_ROOT/SICM
+ls -R $TRAVIS_ROOT/jemalloc
+
 case "x$PORT" in
     xofi)
         ./configure --with-ofi=$TRAVIS_ROOT/libfabric
@@ -66,10 +65,15 @@ case "x$PORT" in
         fi
         ;;
     x)
-        ./configure $CONFIG_OPTS
+        ./configure ${CONFIG_OPTS}
         ;;
+    xmpi-pr)
+        export CFLAGS="-DUSE_SICM=1 -I${TRAVIS_ROOT}/SICM/include ${CFLAGS}"
+        export LDFLAGS="-L${TRAVIS_ROOT}/jemalloc/lib -ljemalloc -L${TRAVIS_ROOT}/SICM/lib -lsicm ${LDFLAGS}"
+        export LD_LIBRARY_PATH="${TRAVIS_ROOT}/SICM/lib:${TRAVIS_ROOT}/jemalloc/lib:${LD_LIBRARY_PATH}"
+        ;&
     x*)
-        ./configure --with-${PORT} $CONFIG_OPTS
+        ./configure --with-${PORT} ${CONFIG_OPTS}
         ;;
 esac
 

--- a/travis/build-run.sh
+++ b/travis/build-run.sh
@@ -52,6 +52,11 @@ case "$MPI_IMPL" in
 esac
 
 # Configure and build
+if test "x$PORT" = "xmpi-pr"
+then
+    export CFLAGS="-DUSE_SICM=1 -I${TRAVIS_ROOT}/SICM/include -L${TRAVIS_ROOT}/jemalloc/lib -ljemalloc -L${TRAVIS_ROOT}/SICM/lib -lsicm ${CFLAGS}"
+fi
+
 ./autogen.sh $TRAVIS_ROOT
 case "x$PORT" in
     xofi)
@@ -103,4 +108,3 @@ then
 else
     mpirun -n 4 ${MAYBE_OVERSUBSCRIBE} ${TEST_NAME}
 fi
-

--- a/travis/install-mpi.sh
+++ b/travis/install-mpi.sh
@@ -51,15 +51,15 @@ cat > mpiimpl.h.patch <<EOF
 -} MPID_Request ATTRIBUTE((__aligned__(32)));
 +} ATTRIBUTE((__aligned__(32))) MPID_Request;
 +/*} MPID_Request ATTRIBUTE((__aligned__(32)));*/
- 
+
  extern MPIU_Object_alloc_t MPID_Request_mem;
  /* Preallocated request objects */
 EOF
                     patch -p0 < mpiimpl.h.patch
-                    mkdir build && cd build
+                    mkdir -p build && cd build
                     ../configure CFLAGS="-w" --prefix=$TRAVIS_ROOT/mpich
                     make -j ${MAKE_JNUM}
-                    make install
+                    make -j ${MAKE_JNUM} install
                 else
                     echo "MPICH already installed"
                 fi
@@ -69,7 +69,7 @@ EOF
                     wget --no-check-certificate https://www.open-mpi.org/software/ompi/v2.0/downloads/openmpi-2.0.2.tar.bz2
                     tar -xjf openmpi-2.0.2.tar.bz2
                     cd openmpi-2.0.2
-                    mkdir build && cd build
+                    mkdir -p build && cd build
                     ../configure CFLAGS="-w" --prefix=$TRAVIS_ROOT/open-mpi \
                                 --without-verbs --without-fca --without-mxm --without-ucx \
                                 --without-portals4 --without-psm --without-psm2 \

--- a/travis/install-sicm.sh
+++ b/travis/install-sicm.sh
@@ -2,7 +2,7 @@
 
 # This should only be run on Linux machines, as OSX does not have NUMA
 # SICM has only been added to mpi-pr
-if [[ ( "$TRAVIS_OS_NAME" != "linux" ) || ( "$PORT" != "mpi-pr" ) ]]; then
+if [ "$TRAVIS_OS_NAME" != "linux" ] || [ "$PORT" != "mpi-pr" ]; then
     exit 1;
 fi
 
@@ -10,7 +10,7 @@ set -e
 set -x
 
 # install dependencies
-sudo add-apt-repository -qq ppa:ubuntu-toolchain-r/test
+sudo add-apt-repository -y ppa:ubuntu-toolchain-r/test
 sudo apt-get update -qq
 sudo apt-get install -qq libhwloc-dev libiomp-dev libnuma-dev libpfm4-dev llvm-3.9-dev numactl
 
@@ -23,14 +23,14 @@ cd SICM
 
 # install jemalloc
 export JEPATH="${TRAVIS_ROOT}/jemalloc"
-./install_deps.sh --jemalloc --build_dir $(pwd) --install_dir ${TRAVIS_ROOT}
-export LD_LIBRARY_PATH=${JEPATH}/lib:${LD_LIBRARY_PATH}
-export PKG_CONFIG_PATH=${JEPATH}/lib/pkgconfig:${PKG_CONFIG_PATH}
+./install_deps.sh --jemalloc --build_dir "$(pwd)" --install_dir "${TRAVIS_ROOT}"
+export LD_LIBRARY_PATH="${JEPATH}/lib:${LD_LIBRARY_PATH}"
+export PKG_CONFIG_PATH="${JEPATH}/lib/pkgconfig:${PKG_CONFIG_PATH}"
 
 # install SICM
 ./autogen.sh
 mkdir -p build
 cd build
-../configure --with-jemalloc=${JEPATH} --prefix=${TRAVIS_ROOT}/SICM
+../configure --with-jemalloc="${JEPATH}" --prefix="${TRAVIS_ROOT}/SICM"
 make -j $(nproc --all)
 make -j $(nproc --all) install

--- a/travis/install-sicm.sh
+++ b/travis/install-sicm.sh
@@ -1,0 +1,36 @@
+#!/bin/sh
+
+# This should only be run on Linux machines, as OSX does not have NUMA
+# SICM has only been added to mpi-pr
+if [[ ( "$TRAVIS_OS_NAME" != "linux" ) || ( "$PORT" != "mpi-pr" ) ]]; then
+    exit 1;
+fi
+
+set -e
+set -x
+
+# install dependencies
+sudo add-apt-repository -qq ppa:ubuntu-toolchain-r/test
+sudo apt-get update -qq
+sudo apt-get install -qq libhwloc-dev libiomp-dev libnuma-dev libpfm4-dev llvm-3.9-dev numactl
+
+TRAVIS_ROOT="$1"
+export PATH=$TRAVIS_ROOT/bin:$PATH
+
+# get SICM
+git clone https://github.com/lanl/SICM.git
+cd SICM
+
+# install jemalloc
+export JEPATH="${TRAVIS_ROOT}/jemalloc"
+./install_deps.sh --jemalloc --build_dir $(pwd) --install_dir ${TRAVIS_ROOT}
+export LD_LIBRARY_PATH=${JEPATH}/lib:${LD_LIBRARY_PATH}
+export PKG_CONFIG_PATH=${JEPATH}/lib/pkgconfig:${PKG_CONFIG_PATH}
+
+# install SICM
+./autogen.sh
+mkdir -p build
+cd build
+../configure --with-jemalloc=${JEPATH} --prefix=${TRAVIS_ROOT}/SICM
+make -j $(nproc --all)
+make -j $(nproc --all) install

--- a/travis/install-sicm.sh
+++ b/travis/install-sicm.sh
@@ -14,11 +14,12 @@ sudo add-apt-repository -y ppa:ubuntu-toolchain-r/test
 sudo apt-get update -qq
 sudo apt-get install -qq libhwloc-dev libiomp-dev libnuma-dev libpfm4-dev llvm-3.9-dev numactl
 
+# set install directory to current location to not cache jemalloc/SICM
 TRAVIS_ROOT="$1"
 export PATH=$TRAVIS_ROOT/bin:$PATH
 
 # get SICM
-git clone https://github.com/lanl/SICM.git
+git clone -b ga-sicm https://github.com/lanl/SICM.git
 cd SICM
 
 # install jemalloc
@@ -31,6 +32,6 @@ export PKG_CONFIG_PATH="${JEPATH}/lib/pkgconfig:${PKG_CONFIG_PATH}"
 ./autogen.sh
 mkdir -p build
 cd build
-../configure --with-jemalloc="${JEPATH}" --prefix="${TRAVIS_ROOT}/SICM"
+../configure --with-jemalloc="${JEPATH}" --prefix="${TRAVIS_ROOT}/SICM" CFLAGS="-std=gnu99 ${CFLAGS}"
 make -j $(nproc --all)
 make -j $(nproc --all) install


### PR DESCRIPTION
Shared memory has been added to [SICM](https://github.com/lanl/SICM), and code has been added to `comex/src-mpi-pr/comex.c` to use the new functionality. The device being used to map shared files to is currently hardcoded to the first `DRAM` device found. The `.travis.yml` file has been updated to use some new features, cache `$HOME/travis`, and to run the SICM build script.

The first 6 tests of `make check` will pass, though most of the rest do not. Travis is expected to fail because the `PORT=mpi-pr` OSX jobs are started up, but SICM is intentionally not built in OSX, as OSX does not have numa.