### PR TITLE
MPI_Errhandler_set was deprecated in MPI-2

### DIFF
--- a/comex/src-mpi-pr/comex.c
+++ b/comex/src-mpi-pr/comex.c
@@ -324,8 +324,6 @@ int comex_init()
     status = MPI_Initialized(&init_flag);
     CHECK_MPI_RETVAL(status);
     assert(init_flag);
-    
-    /*MPI_Errhandler_set(MPI_COMM_WORLD, MPI_ERRORS_RETURN);*/
 
     /* groups */
     comex_group_init();

--- a/tcgmsg/tcgmsg-mpi/misc.c
+++ b/tcgmsg/tcgmsg-mpi/misc.c
@@ -142,7 +142,11 @@ void tcgi_alt_pbegin(int *argc, char **argv[])
 #else
         MPI_Init(argc, argv);
 #endif
+#if defined(MPI_VERSION) && (MPI_VERSION >= 2)
+        MPI_Comm_set_errhandler(TCGMSG_Comm, MPI_ERRORS_RETURN);
+#else
         MPI_Errhandler_set(TCGMSG_Comm, MPI_ERRORS_RETURN);
+#endif
     }
 
     MPI_Comm_size(TCGMSG_Comm, &numprocs);


### PR DESCRIPTION
if using MPI 2.0 or later, use MPI_Comm_set_errhandler, which is the
replacement for MPI_Errhandler_set.

Open-MPI does not support this function anymore, because it was deleted
in MPI-3.