### PR TITLE
MPI_Type_struct was deprecated in MPI-2

### DIFF
--- a/comex/src-armci/message.c
+++ b/comex/src-armci/message.c
@@ -284,7 +284,11 @@ void armci_msg_sel_scope(int scope, void *x, int n, char* op, int type, int cont
         disp[1] = sizeof(long long);
         block[0] = 1;
         block[1] = 1;
+#if defined(MPI_VERSION) && (MPI_VERSION >= 2)
+        MPI_Type_create_struct(2, block, disp, type, &MPI_LONGLONG_INT);
+#else
         MPI_Type_struct(2, block, disp, type, &MPI_LONGLONG_INT);
+#endif
     }
 
     if (strncmp(op, "min", 3) == 0) {


### PR DESCRIPTION
if using MPI 2.0 or later, use MPI_Type_create_struct, which is the
replacement for MPI_Type_struct.