### PR TITLE
Patch autotools/M4 for glibc v2.28

### DIFF
--- a/travis/install-autotools.sh
+++ b/travis/install-autotools.sh
@@ -114,6 +114,14 @@ else
     if patch -p0 -N < secure_snprintf.patch ; then
         echo patch applied
     fi
+    if [ -f 0001-fflush-adjust-to-glibc-2.28-libio.h-removal.patch ] ; then
+        echo glibc v2.28 patch already exists! Using existing copy.
+    else
+        ${download} 0001-fflush-adjust-to-glibc-2.28-libio.h-removal.patch https://gitlab.com/atilla/buildroot/raw/c48f8a64626c60bd1b46804b7cf1a699ff53cdf3/package/m4/0001-fflush-adjust-to-glibc-2.28-libio.h-removal.patch
+    fi
+    if patch -p1 -N < 0001-fflush-adjust-to-glibc-2.28-libio.h-removal.patch ; then
+        echo patch applied
+    fi
     ./configure --prefix=${TOP} && make -j ${MAKE_JNUM} && make install
     if [ "x$?" != "x0" ] ; then
         echo FAILURE 1


### PR DESCRIPTION
libio.h was removed in glibc 2.28. This breaks GNU M4. See [here](https://lists.gnu.org/r/bug-gnulib/2018-03/msg00000.html]).

My GA configure error is [here](https://gist.githubusercontent.com/keipertk/f251a580a44af16de0d66888a590dcd3/raw/e72e95e82d0dc85a45a44ea98dbc9ae01204e97f/ga%2520glibc228)

This PR applies a patch to M4 that was used in both gnulib and buildroot. See [here](https://git.busybox.net/buildroot/commit/?id=c48f8a64626c60bd1b46804b7cf1a699ff53cdf3). The patch solves the issue for GA on my system with glibc 2.28-5.





