### PR TITLE
preprocessor guard mallopt

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -527,6 +527,9 @@ AS_IF([test "x$ga_cv_target" = xLINUX64],
         [x86_64|ppc64],
             [AC_DEFINE([NOUSE_MMAP], [1], [Set some mallopt options])])])
 
+AC_CHECK_FUNCS([mallopt], [have_mallopt=1], [have_mallopt=0])
+AC_DEFINE_UNQUOTED([HAVE_MALLOPT], [$have_mallopt], [Define to 1 if you have the 'mallopt' function.])
+
 # Create proper types for our access functions.
 AS_IF([test "x$ac_cv_sizeof_voidp" = "x$ac_cv_sizeof_int"],
       [ga_access_index_type_c="int"],

--- a/ma/ma.c
+++ b/ma/ma.c
@@ -2507,9 +2507,11 @@ public Boolean MA_init(
     /* segment consists of heap and stack */
     total_bytes = heap_bytes + stack_bytes;
 #ifdef NOUSE_MMAP
+#ifdef HAVE_MALLOPT
     /* disable memory mapped malloc */
     mallopt(M_MMAP_MAX, 0);
     mallopt(M_TRIM_THRESHOLD, -1);
+#endif
 #endif
     /* allocate the segment of memory */
 #ifdef ENABLE_ARMCI_MEM_OPTION


### PR DESCRIPTION
When Linux doesn't use glibc, `mallopt` may be missing (e.g. MUSL).

This fixes https://github.com/GlobalArrays/ga/issues/102.