### PR TITLE
fix for MacOS header brokenness

### DIFF
--- a/gaf2c/drand.c
+++ b/gaf2c/drand.c
@@ -2,6 +2,9 @@
 #   include "config.h"
 #endif
 
+#if HAVE_STDIO_H
+#   include <stdio.h>
+#endif
 #if HAVE_STDLIB_H
 #   include <stdlib.h>
 #endif

--- a/global/src/fapi.c
+++ b/global/src/fapi.c
@@ -9,6 +9,9 @@
 #   include "config.h"
 #endif
 
+#if HAVE_STDIO_H
+#   include <stdio.h>
+#endif
 #if HAVE_STDLIB_H
 #   include <stdlib.h>
 #endif

--- a/global/src/matmul.c
+++ b/global/src/matmul.c
@@ -10,6 +10,9 @@
  *
  *===========================================================*/
 
+#if HAVE_STDIO_H
+#   include <stdio.h>
+#endif
 #if HAVE_STDLIB_H
 #   include <stdlib.h>
 #endif

--- a/ma/string-util.c
+++ b/ma/string-util.c
@@ -29,6 +29,9 @@
  * bytes pointed to).  <Global Comment 1> is concerned with Nstrings.
  */
 
+#if HAVE_STDIO_H
+#   include <stdio.h>
+#endif
 #if HAVE_STDLIB_H
 #   include <stdlib.h>
 #endif

--- a/pario/dra/env.c
+++ b/pario/dra/env.c
@@ -6,6 +6,9 @@
  * $Id: env.c,v 1.1 1997-12-07 11:14:18 d3e129 Exp $
  */
 
+#if HAVE_STDIO_H
+#   include <stdio.h>
+#endif
 #if HAVE_STDLIB_H
 #   include <stdlib.h>
 #endif

--- a/pario/sf/sf_capi.c
+++ b/pario/sf/sf_capi.c
@@ -2,11 +2,14 @@
 #   include "config.h"
 #endif
 
-#if HAVE_MALLOC_H
-#   include <malloc.h>
+#if HAVE_STDIO_H
+#   include <stdio.h>
 #endif
 #if HAVE_STDLIB_H
 #   include <stdlib.h>
+#endif
+#if HAVE_MALLOC_H
+#   include <malloc.h>
 #endif
 
 #include "typesf2c.h"

--- a/tcgmsg/tcgmsg-mpi/clustercheck.c
+++ b/tcgmsg/tcgmsg-mpi/clustercheck.c
@@ -2,8 +2,9 @@
 #   include "config.h"
 #endif
 
-#include <mpi.h>
-
+#if HAVE_STDIO_H
+#   include <stdio.h>
+#endif
 #if HAVE_STDLIB_H
 #   include <stdlib.h>
 #endif
@@ -19,6 +20,8 @@
 #if HAVE_UNISTD_H
 #   include <unistd.h>
 #endif
+
+#include <mpi.h>
 
 #define HOSTNAME_LEN 128 
 static char myname[HOSTNAME_LEN], rootname[HOSTNAME_LEN];


### PR DESCRIPTION
problem: https://github.com/Homebrew/homebrew-core/issues/40676
solution: https://github.com/Homebrew/homebrew-core/issues/40676#issuecomment-513506908

This may be fixed in Catalina but I haven't upgraded.

@edoapra I don't know if anybody else sees this on Mac, but I had to manually patch GA 5.7.2 just now.  If it is only me, don't worry about it, but if others see this, then perhaps we can drop a GA 5.7.3 release with this patch applied.