### PR TITLE
patch for ifx -loopopt=0 issue

### DIFF
--- a/travis/install-autotools.sh
+++ b/travis/install-autotools.sh
@@ -163,6 +163,9 @@ else
     cd ${TOP}/${TDIR}
     cp ${TOP}/bin/config.guess ./build-aux/config.guess
     cp ${TOP}/bin/config.sub ./build-aux/config.sub
+# patch for ifx -loopopt=0 issue
+    wget https://github.com/autotools-mirror/autoconf/commit/ae26b9b44c183c41b84fc36ff70082713295d621.patch
+    patch -p1 < ae26b9b44c183c41b84fc36ff70082713295d621.patch
     ./configure --prefix=${TOP} && make -j ${MAKE_JNUM} && make install
     if [ "x$?" != "x0" ] ; then
         echo FAILURE 3


### PR DESCRIPTION
You cannot compile with FC=ifx unless this patch is applied (that should make into the upcoming 2.70 autoconf release)