### PR TITLE
revert to latest sicm commit known to work on travis CI

### DIFF
--- a/travis/install-sicm.sh
+++ b/travis/install-sicm.sh
@@ -23,14 +23,15 @@ cd jemalloc
 export JEPATH="${TRAVIS_ROOT}/jemalloc"
 sh autogen.sh
 ./configure --with-jemalloc-prefix=je_ --prefix="${JEPATH}"
-make
-make install
+make -j $(nproc --all)
+make -j $(nproc --all) install
 export LD_LIBRARY_PATH="${JEPATH}/lib:${LD_LIBRARY_PATH}"
 export PKG_CONFIG_PATH="${JEPATH}/lib/pkgconfig:${PKG_CONFIG_PATH}"
 
 # get SICM
 git clone  https://github.com/lanl/SICM.git
 cd SICM
+git checkout 5944a56e0ccf159b72ce6fe980745b021216b580
 
 
 # install SICM


### PR DESCRIPTION
the GA build that uses SICM started to fail after commit https://github.com/lanl/SICM/commit/f52536bfd20cf5c88be8aa0a826bce3e1358cdd1 in the SIC repository.
After reverting to the previous commit, the travis CI test works (SICM builds again)