### PR TITLE
fix for  aarch64 relocation truncated to fit error

### DIFF
--- a/tcgmsg/tcgmsg-mpi/nxtval-armci.c
+++ b/tcgmsg/tcgmsg-mpi/nxtval-armci.c
@@ -16,8 +16,8 @@
 static long pnxtval_counter_val;
 static long *pnxtval_counter=&pnxtval_counter_val;
 int nxtval_installed=0;
-extern int     *tcgi_argc;
-extern char  ***tcgi_argv;
+extern int     tcgi_argc;
+extern char  **tcgi_argv;
 #define INCR 1   /**< increment for NXTVAL */
 #define BUSY -1L /**< indicates somebody else updating counter*/
 #define NXTV_SERVER ((int)NNODES_() -1)
@@ -38,7 +38,7 @@ long NXTVAL_(long *mproc)
     int rc;
     int server = NXTV_SERVER;         /* id of server process */
 
-    install_nxtval(tcgi_argc, tcgi_argv);
+    install_nxtval(&tcgi_argc, &tcgi_argv);
 
     if (SR_parallel) {
         if (DEBUG_) {


### PR DESCRIPTION
This commit should fix the following error I have seen on aarch64 when using mpich in the link phase of NWChem
```
/builddir/build/BUILD/nwchem-7.0.2/src/tools/install/lib/libga.a(nxtval-armci.o): in function `armci_tcgmsg_nxtval':
/builddir/build/BUILD/nwchem-7.0.2/src/tools/build/../ga-5.7.2/tcgmsg/tcgmsg-mpi/nxtval-armci.c:41:(.text+0x170): relocation truncated to fit: R_AARCH64_LDST64_ABS_LO12_NC against symbol `tcgi_argc' defined in .bss section in /builddir/build/BUILD/nwchem-7.0.2/src/tools/install/lib/libga.a(misc.o)
/usr/bin/ld: /builddir/build/BUILD/nwchem-7.0.2/src/tools/build/../ga-5.7.2/tcgmsg/tcgmsg-mpi/nxtval-armci.c:41: warning: one possible cause of this error is that the symbol is being referenced in the indicated code as if it had a larger alignment than was declared where it was defined
```