### PR TITLE
Fix ctest of C programs

### DIFF
--- a/global/testing/elempatch.c
+++ b/global/testing/elempatch.c
@@ -1591,10 +1591,7 @@ test_fun (int type, int dim, int OP)
   return ok;
 }
 
-int
-main (argc, argv)
-  int argc;
-  char **argv;
+int main(int argc, char **argv)
 {
   int heap = 20000, stack = 20000;
   int me, nproc;

--- a/global/testing/ga-mpi.c
+++ b/global/testing/ga-mpi.c
@@ -157,12 +157,8 @@ int root=0, grp_me=-1;
      GA_Destroy(g_a);
      GA_Destroy(g_b);
 }
-     
 
-
-int main(argc, argv)
-int argc;
-char **argv;
+int main(int argc, char **argv)
 {
 int heap=20000, stack=20000;
 int me, nproc;

--- a/global/testing/ga_lu.c
+++ b/global/testing/ga_lu.c
@@ -449,7 +449,7 @@ int main(int argc, char **argv) {
     /* *****************************************************************
      * Terminate MPI/TCGMSG-MPI, GA and MA
      * *****************************************************************/
-    if(me==0)printf("Success\n");
+    if (me == 0) printf("All tests successful\n");
     GA_Terminate();
 
     MP_FINALIZE();

--- a/global/testing/matrixc.c
+++ b/global/testing/matrixc.c
@@ -301,12 +301,8 @@ void do_work()
   NGA_Destroy(g_a);
   NGA_Destroy(g_v);
 }
-     
 
-
-int main(argc, argv)
-int argc;
-char **argv;
+int main(int argc, char **argv)
 {
 int heap=20000, stack=20000;
 int me, nproc;

--- a/global/testing/normc.c
+++ b/global/testing/normc.c
@@ -496,7 +496,7 @@ int me, nproc;
     
     do_work();
 
-    if(me==0)printf("Terminating ..\n");
+    if (me == 0) printf("All tests successful\n");
     GA_Terminate();
 
     MP_FINALIZE();

--- a/global/testing/normc.c
+++ b/global/testing/normc.c
@@ -472,12 +472,8 @@ void do_work()
   }
   NGA_Destroy(g_a);
 }
-     
 
-
-int main(argc, argv)
-int argc;
-char **argv;
+int main(int argc, char **argv)
 {
 int heap=20000, stack=20000;
 int me, nproc;

--- a/global/testing/ntestc.c
+++ b/global/testing/ntestc.c
@@ -240,11 +240,8 @@ double *buf;
      GA_Destroy(g_a);
      GA_Destroy(g_b);
 }
-     
 
-int main(argc, argv)
-int argc;
-char **argv;
+int main(int argc, char** argv)
 {
 Integer heap=300000, stack=300000;
 int me, nproc;

--- a/global/testing/ntestfc.c
+++ b/global/testing/ntestfc.c
@@ -286,9 +286,9 @@ int me, nproc;
     
     do_work();
 
-    if(me==0)printf("\nSuccess\n\n");
-    GA_Terminate();
+    if (me == 0) printf("\nAll tests successful\n");
 
+    GA_Terminate();
     MP_FINALIZE();
 
     return 0;

--- a/global/testing/ntestfc.c
+++ b/global/testing/ntestfc.c
@@ -258,11 +258,8 @@ double *buf;
      GA_Destroy(g_a);
      GA_Destroy(g_b);
 }
-     
 
-int main(argc, argv)
-int argc;
-char **argv;
+int main(int argc, char** argv)
 {
 Integer heap=300000, stack=300000;
 int me, nproc;

--- a/global/testing/packc.c
+++ b/global/testing/packc.c
@@ -285,6 +285,9 @@ int main(int argc, char **argv)
         }
     }
 
+    if (me == 0)
+      printf("All tests successful\n");
+
     GA_Terminate();
     MP_FINALIZE();
 

--- a/global/testing/patch_enumc.c
+++ b/global/testing/patch_enumc.c
@@ -126,6 +126,9 @@ int main(int argc, char **argv)
 #endif
     test_C_DCPL();
 
+    if (me == 0)
+      printf("All tests successful\n");
+
     GA_Terminate();
     MP_FINALIZE();
 

--- a/global/testing/perf2.c
+++ b/global/testing/perf2.c
@@ -105,9 +105,13 @@ int main(int argc, char **argv)
   }
 #endif
 
+  if (me == 0)
+    printf("All tests successful\n");
+
   GA_Terminate();
   MP_FINALIZE();
-  return(0);
+
+  return 0;
 }
 
 

--- a/global/testing/print.c
+++ b/global/testing/print.c
@@ -49,7 +49,11 @@ int main(int argc, char **argv)
         NGA_Release(g_a, &lo, &hi);
     }
 
+    if (GA_Nodeid() == 0)
+      printf("All tests successful\n");
+
     GA_Terminate();
     MP_FINALIZE();
-    exit(EXIT_SUCCESS);
+
+    return 0;
 }

--- a/global/testing/scan_addc.c
+++ b/global/testing/scan_addc.c
@@ -301,6 +301,9 @@ int main(int argc, char **argv)
     }
     }
 
+    if (me == 0)
+      printf("All tests successful\n");
+
     GA_Terminate();
     MP_FINALIZE();
 

--- a/global/testing/scan_copyc.c
+++ b/global/testing/scan_copyc.c
@@ -250,6 +250,9 @@ int main(int argc, char **argv)
     }
     }
 
+    if (me == 0)
+      printf("All tests successful\n");
+
     GA_Terminate();
     MP_FINALIZE();
 

--- a/global/testing/simple_groups_commc.c
+++ b/global/testing/simple_groups_commc.c
@@ -74,6 +74,9 @@ int main(int argc, char **argv) {
         GA_Sync();
     }
 
+    if (me == 0)
+      printf("All tests successful\n");
+
     GA_Terminate();
     MP_FINALIZE();
 

--- a/global/testing/testc.c
+++ b/global/testing/testc.c
@@ -116,9 +116,9 @@ int me, nproc;
     
     do_work();
 
-    if(me==0)printf("Terminating ..\n");
-    GA_Terminate();
+    if (me == 0) printf("All tests successful\n");
 
+    GA_Terminate();
     MP_FINALIZE();
 
     return 0;

--- a/global/testing/testc.c
+++ b/global/testing/testc.c
@@ -92,12 +92,8 @@ double buf[N], err, alpha, beta;
      GA_Destroy(g_a);
      GA_Destroy(g_b);
 }
-     
 
-
-int main(argc, argv)
-int argc;
-char **argv;
+int main(int argc, char **argv)
 {
 int heap=20000, stack=20000;
 int me, nproc;

--- a/global/testing/testmult.c
+++ b/global/testing/testmult.c
@@ -230,9 +230,9 @@ DoublePrecision time;
       printf("%d: GEMM Total Time = %lf\n", me, gTime);
     */
 
-    if(me==0)printf("\nSuccess\n\n");
-    GA_Terminate();
+    if (me == 0) printf("\nAll tests successful\n");
 
+    GA_Terminate();
     MP_FINALIZE();
 
     return 0;

--- a/global/testing/testmultrect.c
+++ b/global/testing/testmultrect.c
@@ -58,6 +58,10 @@ int main(int argc, char **argv) {
 
     /* Clean up */
     ret = mr_cleanup();
+
+    if (me == 0)
+      printf("All tests successful\n");
+
     GA_Terminate();
     MP_FINALIZE();
 

--- a/global/testing/unit-tests/ga_acc.c
+++ b/global/testing/unit-tests/ga_acc.c
@@ -15,7 +15,7 @@
 #define DIM 2
 #define SIZE 5
 
-main(int argc, char **argv)
+int main(int argc, char **argv)
 {
   int rank, nprocs, i, j;
   int g_A, **local_A=NULL, **local_B=NULL; 

--- a/global/testing/unit-tests/ga_add.c
+++ b/global/testing/unit-tests/ga_add.c
@@ -16,7 +16,8 @@
 
 #define DIM 2
 #define SIZE 5
-main(int argc, char **argv)
+
+int main(int argc, char **argv)
 {
   int rank, nprocs, i, j;
   int g_A, g_B, g_C, **local_C=NULL, dims[DIM]={SIZE,SIZE}, val1=5, val2=4, alpha=3, beta=2;

--- a/global/testing/unit-tests/ga_add_constantpatch.c
+++ b/global/testing/unit-tests/ga_add_constantpatch.c
@@ -16,7 +16,7 @@
 #define DIM 2
 #define SIZ 5
 
-main(int argc, char **argv)
+int main(int argc, char **argv)
 {
   int rank, nprocs, i, j;
   int g_A, local_A[SIZ][SIZ], dims[DIM]={SIZ,SIZ}, val1=5, alpha=3;

--- a/global/testing/unit-tests/ga_add_diagonal.c
+++ b/global/testing/unit-tests/ga_add_diagonal.c
@@ -15,7 +15,7 @@
 #define DIM 2
 #define GSIZE 5
 
-main(int argc, char **argv)
+int main(int argc, char **argv)
 {
   int rank, nprocs, i, j;
   int g_A, g_B, g_V, local_A[5][5], local_B[5][5], vsize=GSIZE;  

--- a/global/testing/unit-tests/ga_add_patch.c
+++ b/global/testing/unit-tests/ga_add_patch.c
@@ -16,7 +16,7 @@
 
 #define DIM 2
 
-main(int argc, char **argv)
+int main(int argc, char **argv)
 {
   int rank, nprocs, i, j;
   int g_A, g_B, g_C, local_C[DIM][DIM], dims[DIM]={5,5}, val1=5, val2=4, alpha=3, beta=2, ld=5;

--- a/global/testing/unit-tests/ga_copy2.c
+++ b/global/testing/unit-tests/ga_copy2.c
@@ -17,7 +17,7 @@
 #define DIM 2
 #define SIZE 5
 
-main(int argc, char **argv)
+int main(int argc, char **argv)
 {
   int rank, nprocs, i, j;
   double g_A, g_B; 

--- a/global/testing/unit-tests/ga_copy3.c
+++ b/global/testing/unit-tests/ga_copy3.c
@@ -17,7 +17,7 @@
 #define DIM 2
 #define SIZE 5
 
-main(int argc, char **argv)
+int main(int argc, char **argv)
 {
   int rank, nprocs, i, j;
   int g_A, g_B,  local_A[SIZE][SIZE], local_B[SIZE][SIZE]; 

--- a/global/testing/unit-tests/ga_copypatch.c
+++ b/global/testing/unit-tests/ga_copypatch.c
@@ -16,7 +16,7 @@
 #define DIM 2
 #define SIZE 5
 
-main(int argc, char **argv)
+int main(int argc, char **argv)
 {
   int rank, nprocs, i, j;
   int g_A, g_B, local_A[SIZE][SIZE]; 

--- a/global/testing/unit-tests/ga_copypatch2.c
+++ b/global/testing/unit-tests/ga_copypatch2.c
@@ -17,7 +17,7 @@
 #define DIM 2
 #define SIZE 5
 
-main(int argc, char **argv)
+int main(int argc, char **argv)
 {
   int rank, nprocs, i, j;
   int g_A, g_B, local_A[SIZE][SIZE]; 

--- a/global/testing/unit-tests/ga_create.c
+++ b/global/testing/unit-tests/ga_create.c
@@ -93,8 +93,7 @@ fourth_dimension(int rank, int nprocs)
   GA_Destroy(g_A);							
 }							
 
-						
-main(int argc, char **argv)				
+int main(int argc, char **argv)
 {							
   int rank, nprocs, i;					
 

--- a/global/testing/unit-tests/ga_create1.c
+++ b/global/testing/unit-tests/ga_create1.c
@@ -28,7 +28,7 @@ void create_ga(int ndim, int datatypes)
   GA_Destroy(g_A);							
 }
 
-main(int argc, char **argv)				
+int main(int argc, char **argv)
 {							
   int rank, nprocs, i, j;					
 

--- a/global/testing/unit-tests/ga_create2.c
+++ b/global/testing/unit-tests/ga_create2.c
@@ -30,8 +30,7 @@ void create_ga(int ndim)
   GA_Destroy(g_A);							
 }
 
-
-main(int argc, char **argv)				
+int main(int argc, char **argv)
 {							
   int rank, nprocs, i;					
 

--- a/global/testing/unit-tests/ga_create3.c
+++ b/global/testing/unit-tests/ga_create3.c
@@ -31,7 +31,7 @@ void create_ga(int ndim, int datatypes)
   GA_Destroy(g_A);							
 }
 
-main(int argc, char **argv)				
+int main(int argc, char **argv)
 {							
   int rank, nprocs, i, j;					
   //  int datatypes[NUM_TYPES] = {C_INT, C_DBL, C_LONG};

--- a/global/testing/unit-tests/ga_create_handle.c
+++ b/global/testing/unit-tests/ga_create_handle.c
@@ -11,7 +11,7 @@
 #include"macdecls.h"
 #include"ga_unit.h"
 
-main(int argc, char **argv)
+int main(int argc, char **argv)
 {
   int rank, nprocs;
   int g_A, g_B;

--- a/global/testing/unit-tests/ga_create_irreg.c
+++ b/global/testing/unit-tests/ga_create_irreg.c
@@ -170,7 +170,7 @@ auto_number2(int rank, int nprocs)
   GA_Destroy(g_B);
 }
 
-main(int argc, char **argv)
+int main(int argc, char **argv)
 {
   int rank, nprocs;
 

--- a/global/testing/unit-tests/ga_create_irreg2.c
+++ b/global/testing/unit-tests/ga_create_irreg2.c
@@ -173,7 +173,7 @@ auto_number2(int rank, int nprocs)
   GA_Destroy(g_B);
 }
 
-main(int argc, char **argv)
+int main(int argc, char **argv)
 {
   int rank, nprocs;
 

--- a/global/testing/unit-tests/ga_create_irreg3.c
+++ b/global/testing/unit-tests/ga_create_irreg3.c
@@ -29,7 +29,7 @@ create_irreg_ga(int ndim)
   GA_Destroy(g_A);							
 }
 
-main(int argc, char **argv)				
+int main(int argc, char **argv)
 {							
   int rank, nprocs, i;					
 

--- a/global/testing/unit-tests/ga_destroy.c
+++ b/global/testing/unit-tests/ga_destroy.c
@@ -13,7 +13,7 @@
 
 #define DIM 2
 
-main(int argc, char **argv)
+int main(int argc, char **argv)
 {
   int rank, nprocs, i;
   int g_A,  value=5; 

--- a/global/testing/unit-tests/ga_dgop.c
+++ b/global/testing/unit-tests/ga_dgop.c
@@ -166,8 +166,7 @@ absmin_operator(int rank, int nprocs, int n)
     }
 }
 
-
-main(int argc, char **argv)
+int main(int argc, char **argv)
 {
 
   int rank, nprocs, n=10;

--- a/global/testing/unit-tests/ga_dot.c
+++ b/global/testing/unit-tests/ga_dot.c
@@ -57,7 +57,7 @@ op=GA_Ddot(g_A, g_B);
 }
 */
 
-main(int argc, char **argv)
+int main(int argc, char **argv)
 {
   int rank, nprocs;
 

--- a/global/testing/unit-tests/ga_duplicate.c
+++ b/global/testing/unit-tests/ga_duplicate.c
@@ -14,7 +14,7 @@
 
 #define DIM 2
 
-main(int argc, char **argv)
+int main(int argc, char **argv)
 {
   int rank, nprocs, i;
   double g_A, g_B; 

--- a/global/testing/unit-tests/ga_elem_dividepatch.c
+++ b/global/testing/unit-tests/ga_elem_dividepatch.c
@@ -14,7 +14,7 @@
 
 #define DIM 2
 
-main(int argc, char **argv)
+int main(int argc, char **argv)
 {
   int rank, nprocs, i, j;
   int g_A, g_B, g_C, local_C[DIM][DIM]; 

--- a/global/testing/unit-tests/ga_elem_maximumpatch.c
+++ b/global/testing/unit-tests/ga_elem_maximumpatch.c
@@ -14,7 +14,7 @@
 
 #define DIM 2
 
-main(int argc, char **argv)
+int main(int argc, char **argv)
 {
   int rank, nprocs, i, j;
   int g_A, g_B, g_C, local_C[DIM][DIM], dims[DIM]={5,5};

--- a/global/testing/unit-tests/ga_elem_multiplypatch.c
+++ b/global/testing/unit-tests/ga_elem_multiplypatch.c
@@ -14,7 +14,7 @@
 
 #define DIM 2
 
-main(int argc, char **argv)
+int main(int argc, char **argv)
 {
   int rank, nprocs, i, j;
   int g_A, g_B, g_C, local_C[DIM][DIM]; 

--- a/global/testing/unit-tests/ga_fillpatch.c
+++ b/global/testing/unit-tests/ga_fillpatch.c
@@ -62,7 +62,7 @@ fillonly(int rank, int nprocs)
   GA_Destroy(g_A);
 }
 
-main(int argc, char **argv)
+int main(int argc, char **argv)
 {
   int rank, nprocs;
   

--- a/global/testing/unit-tests/ga_fillpatch1.c
+++ b/global/testing/unit-tests/ga_fillpatch1.c
@@ -14,7 +14,7 @@
 
 #define DIM 2
 
-main(int argc, char **argv)
+int main(int argc, char **argv)
 {
   int rank, nprocs, i, j;
   int g_A, g_B, local_A[5][5], local_B[5][5];  

--- a/global/testing/unit-tests/ga_gather.c
+++ b/global/testing/unit-tests/ga_gather.c
@@ -17,7 +17,7 @@
 #define N 5
 #define D 2
 
-main(int argc, char **argv)
+int main(int argc, char **argv)
 {
   int rank, nprocs;
   int g_A, dims[D]={5,10}, local_A[N], local_G[N], sub_array[N][D], **s_array=NULL;

--- a/global/testing/unit-tests/ga_gather2.c
+++ b/global/testing/unit-tests/ga_gather2.c
@@ -16,7 +16,7 @@
 #define N 5
 #define D 2
 
-main(int argc, char **argv)
+int main(int argc, char **argv)
 {
   int rank, nprocs;
   int g_A, dims[D]={5,10}, local_A[N], local_G[N], **sub_array=NULL, **s_array=NULL;

--- a/global/testing/unit-tests/ga_gather3.c
+++ b/global/testing/unit-tests/ga_gather3.c
@@ -17,7 +17,7 @@
 #define N 5
 #define D 2
 
-main(int argc, char **argv)
+int main(int argc, char **argv)
 {
   int rank, nprocs;
   int g_A, dims[D]={SIZE,SIZE}, *local_A=NULL, *local_G=NULL, **sub_array=NULL, **s_array=NULL;

--- a/global/testing/unit-tests/ga_get.c
+++ b/global/testing/unit-tests/ga_get.c
@@ -14,7 +14,7 @@
 #define DIM 2
 #define SIZE 5
 
-main(int argc, char **argv)
+int main(int argc, char **argv)
 {
   int rank, nprocs, i, j;
   int g_A, **local_A=NULL, **local_B=NULL; 

--- a/global/testing/unit-tests/ga_get_blockinfo.c
+++ b/global/testing/unit-tests/ga_get_blockinfo.c
@@ -15,7 +15,7 @@
 
 #define DIM 2
 
-main(int argc, char **argv)
+int main(int argc, char **argv)
 {
   int rank, nprocs, i;
   int g_A, g_B; 

--- a/global/testing/unit-tests/ga_get_diagonal.c
+++ b/global/testing/unit-tests/ga_get_diagonal.c
@@ -16,7 +16,7 @@
 #define DIM 2
 #define GSIZE 5
 
-main(int argc, char **argv)
+int main(int argc, char **argv)
 {
   int rank, nprocs, i, j;
   int g_A, g_B, g_V, g_V2;

--- a/global/testing/unit-tests/ga_igop2.c
+++ b/global/testing/unit-tests/ga_igop2.c
@@ -65,7 +65,7 @@ checking_operator (int rank, int nprocs)
   */
 }
 
-main(int argc, char **argv)
+int main(int argc, char **argv)
 {
 
   int rank, nprocs;

--- a/global/testing/unit-tests/ga_lgop.c
+++ b/global/testing/unit-tests/ga_lgop.c
@@ -162,8 +162,7 @@ absmin_operator(int rank, int nprocs, int n)
     }
 }
 
-
-main(int argc, char **argv)
+int main(int argc, char **argv)
 {
 
   int rank, nprocs, n=10;

--- a/global/testing/unit-tests/ga_median.c
+++ b/global/testing/unit-tests/ga_median.c
@@ -8,7 +8,7 @@
 #define DIM 2
 #define SIZE 5
 
- main(int argc, char **argv)
+int main(int argc, char **argv)
 {
 
   int rank, nprocs;

--- a/global/testing/unit-tests/ga_pgroup_create.c
+++ b/global/testing/unit-tests/ga_pgroup_create.c
@@ -12,7 +12,8 @@
 #include"macdecls.h"
 
 #define PGSIZE 4
-main(int argc, char **argv)
+
+int main(int argc, char **argv)
 {
   int rank, nprocs, i, j;
   int p_Geven, p_Godd, list[PGSIZE], p_size, *list_even=NULL, *list_odd=NULL, even, odd;

--- a/global/testing/unit-tests/ga_pgroup_create2.c
+++ b/global/testing/unit-tests/ga_pgroup_create2.c
@@ -13,7 +13,7 @@
 #include"macdecls.h"
 #include"ga_unit.h"
 
-main(int argc, char **argv)
+int main(int argc, char **argv)
 {
   int rank, nprocs, i, j;
   int p_Geven, p_Godd, p_size, mod, p_size_mod, *list_even=NULL, *list_odd=NULL;

--- a/global/testing/unit-tests/ga_pgroup_create3.c
+++ b/global/testing/unit-tests/ga_pgroup_create3.c
@@ -13,7 +13,7 @@
 #include"macdecls.h"
 #include"ga_unit.h"
 
-main(int argc, char **argv)
+int main(int argc, char **argv)
 {
   int rank, nprocs, i, j;
   int p_Geven, p_Godd, p_size, mod, p_size_mod, *list_even=NULL, *list_odd=NULL;

--- a/global/testing/unit-tests/ga_pgroup_create4.c
+++ b/global/testing/unit-tests/ga_pgroup_create4.c
@@ -13,7 +13,7 @@
 #include"macdecls.h"
 #include"ga_unit.h"
 
-main(int argc, char **argv)
+int main(int argc, char **argv)
 {
   int rank, nprocs, i, j;
   int p_Geven, p_Godd, p_size, mod, p_size_mod, *list_even=NULL, *list_odd=NULL;

--- a/global/testing/unit-tests/ga_pgroup_create5.c
+++ b/global/testing/unit-tests/ga_pgroup_create5.c
@@ -13,7 +13,7 @@
 #include"macdecls.h"
 #include"ga_unit.h"
 
-main(int argc, char **argv)
+int main(int argc, char **argv)
 {
   int rank, nprocs, i, j;
   int p_Geven, p_Godd,  p_size, mod, p_size_mod, *list_even=NULL, *list_odd=NULL;

--- a/global/testing/unit-tests/ga_pgroup_destroy.c
+++ b/global/testing/unit-tests/ga_pgroup_destroy.c
@@ -14,7 +14,7 @@
 #include"macdecls.h"
 #include"ga_unit.h"
 
-main(int argc, char **argv)
+int main(int argc, char **argv)
 {
   int rank, nprocs, i, j;
   int p_Geven, p_Godd, p_size, mod, p_size_mod, *list_even=NULL, *list_odd=NULL;

--- a/global/testing/unit-tests/ga_pgroup_destroy2.c
+++ b/global/testing/unit-tests/ga_pgroup_destroy2.c
@@ -14,7 +14,7 @@
 #include"macdecls.h"
 #include"ga_unit.h"
 
-main(int argc, char **argv)
+int main(int argc, char **argv)
 {
   int rank, nprocs, i, j;
   int p_Geven, p_Godd, p_size, mod, p_size_mod, *list_even=NULL, *list_odd=NULL;

--- a/global/testing/unit-tests/ga_pgroup_nnodes_nodeid.c
+++ b/global/testing/unit-tests/ga_pgroup_nnodes_nodeid.c
@@ -90,7 +90,7 @@ two_half_pgroup(int rank, int nprocs)
     printf("%d: My ID is %d :: %d --- two\n", rank, GA_Pgroup_nodeid(p_Gtwo), GA_Pgroup_nnodes(p_Gtwo));
 }
 
-main(int argc, char **argv)
+int main(int argc, char **argv)
 {
   int rank, nprocs;
   

--- a/global/testing/unit-tests/ga_pgroup_setdefault.c
+++ b/global/testing/unit-tests/ga_pgroup_setdefault.c
@@ -12,7 +12,7 @@
 #include"ga.h"
 #include"macdecls.h"
 
-main(int argc, char **argv)
+int main(int argc, char **argv)
 {
   int rank, nprocs, i, j;
   int p_Geven, p_Godd, p_size, *list_even=NULL, *list_odd=NULL;

--- a/global/testing/unit-tests/ga_put.c
+++ b/global/testing/unit-tests/ga_put.c
@@ -15,7 +15,7 @@
 #define DIM 2
 #define SIZE 5
 
-main(int argc, char **argv)
+int main(int argc, char **argv)
 {
   int rank, nprocs, i, j;
   int g_A, **local_A=NULL, **local_B=NULL; 

--- a/global/testing/unit-tests/ga_put2.c
+++ b/global/testing/unit-tests/ga_put2.c
@@ -14,7 +14,7 @@
 #define DIM 2
 #define SIZE 20
 
-main(int argc, char **argv)
+int main(int argc, char **argv)
 {
   int rank, nprocs, i, j;
   int g_A, **local_A=NULL, **local_B=NULL; 

--- a/global/testing/unit-tests/ga_scale2.c
+++ b/global/testing/unit-tests/ga_scale2.c
@@ -77,7 +77,8 @@ two_dimension_array(int rank, int val_A, int val_scale)
     }
   GA_Destroy(g_A);
 }
-main(int argc, char **argv)
+
+int main(int argc, char **argv)
 {
   int rank, nprocs;
   int val_scale=5, val_A=5, val_V=3;

--- a/global/testing/unit-tests/ga_scale_cols.c
+++ b/global/testing/unit-tests/ga_scale_cols.c
@@ -16,7 +16,7 @@
 #define DIM 2
 #define SIZE 5
 
-main(int argc, char **argv)
+int main(int argc, char **argv)
 {
   int rank, nprocs;
   int g_A, g_V, val2=3, local_A[SIZE][SIZE], dims_V=SIZE, local_V[dims_V], local_Ar[SIZE][SIZE]; 

--- a/global/testing/unit-tests/ga_scale_patch.c
+++ b/global/testing/unit-tests/ga_scale_patch.c
@@ -13,7 +13,7 @@
 #define DIM 2
 #define SIZE 5
 
-main(int argc, char **argv)
+int main(int argc, char **argv)
 {
   int rank, nprocs;
   int g_A, g_V,  val1=5, val2=5, local_A[SIZE][SIZE], dims_V=SIZE; 

--- a/global/testing/unit-tests/ga_scale_rows.c
+++ b/global/testing/unit-tests/ga_scale_rows.c
@@ -15,7 +15,7 @@
 #define DIM 2
 #define SIZE 5
 
-main(int argc, char **argv)
+int main(int argc, char **argv)
 {
   int rank, nprocs;
   int g_A, g_V,  val1=5, val2=5, local_A[SIZE][SIZE], dims_V=SIZE, local_V[dims_V]; 

--- a/global/testing/unit-tests/ga_scatter.c
+++ b/global/testing/unit-tests/ga_scatter.c
@@ -14,7 +14,7 @@
 #define N 5
 #define D 2
 
-main(int argc, char **argv)
+int main(int argc, char **argv)
 {
   int rank, nprocs;
   int g_A, dims[D]={5,10}, local_A[N], sub_array[N][D], **s_array=NULL;

--- a/global/testing/unit-tests/ga_set_diagonal.c
+++ b/global/testing/unit-tests/ga_set_diagonal.c
@@ -16,7 +16,7 @@
 #define DIM 2
 #define GSIZE 5
 
-main(int argc, char **argv)
+int main(int argc, char **argv)
 {
   int rank, nprocs, i, j;
   int g_A, g_V, g_V2;

--- a/global/testing/unit-tests/ga_set_restricted.c
+++ b/global/testing/unit-tests/ga_set_restricted.c
@@ -65,7 +65,7 @@ group_of_four(int nprocs)
     printf("-%d\t-%d\t-%d\t-%d\t\n", list_a[i], list_b[i], list_c[i], list_d[i]);
 }
 
-main(int argc, char **argv)
+int main(int argc, char **argv)
 {
   int rank, nprocs;
   int g_A, g_B;

--- a/global/testing/unit-tests/ga_solve.c
+++ b/global/testing/unit-tests/ga_solve.c
@@ -16,7 +16,7 @@
 #define SIZE 10
 #define MAX_DIM 7
 
-main(int argc, char **argv)
+int main(int argc, char **argv)
 {
   int rank, nprocs, i, j;
   int g_A, g_B;

--- a/global/testing/unit-tests/ga_sync.c
+++ b/global/testing/unit-tests/ga_sync.c
@@ -12,7 +12,7 @@
 
 #define DIM 2
 
-main(int argc, char **argv)
+int main(int argc, char **argv)
 {
   int rank, nprocs, i;
   int g_A,  value=5; 

--- a/global/testing/unit-tests/ga_transpose.c
+++ b/global/testing/unit-tests/ga_transpose.c
@@ -16,7 +16,7 @@
 #define DIM 2
 #define SIZE 5
 
-main(int argc, char **argv)
+int main(int argc, char **argv)
 {
   int rank, nprocs, i, j;
   int g_A, g_B, value=5, local_GA[SIZE][SIZE], local_A[SIZE][SIZE], local_B[SIZE][SIZE];  

--- a/global/testing/unit-tests/ga_transpose2.c
+++ b/global/testing/unit-tests/ga_transpose2.c
@@ -31,7 +31,8 @@ validate_transpose(int local_A[][SIZE], int local_B[][SIZE])
     }
   
 }
-main(int argc, char **argv)
+
+int main(int argc, char **argv)
 {
   int rank, nprocs, i, j;
   int g_A, g_B, **local_value=NULL;

--- a/global/testing/unit-tests/ga_transpose3.c
+++ b/global/testing/unit-tests/ga_transpose3.c
@@ -47,7 +47,8 @@ validate_transpose(int g_A, int g_B, int* lo, int* hi, int ld)
     }
   
 }
-main(int argc, char **argv)
+
+int main(int argc, char **argv)
 {
   int rank, nprocs, i, j;
   int g_A, g_B, **local_value=NULL;

--- a/global/testing/unit-tests/ga_zerodiagonal.c
+++ b/global/testing/unit-tests/ga_zerodiagonal.c
@@ -15,7 +15,7 @@
 #define DIM 2
 #define GSIZE 5
 
-main(int argc, char **argv)
+int main(int argc, char **argv)
 {
   int rank, nprocs, i, j;
   int g_A, g_B, g_V, local_A[5][5], local_B[5][5], vsize=GSIZE;  

--- a/global/testing/unit-tests/ga_zeropatch.c
+++ b/global/testing/unit-tests/ga_zeropatch.c
@@ -16,7 +16,8 @@
 
 #define DIM 2
 #define SIZE 5
-main(int argc, char **argv)
+
+int main(int argc, char **argv)
 {
   int rank, nprocs, i, j;
   int g_A, g_B, local_A[SIZE][SIZE], local_B[SIZE][SIZE];  

--- a/global/testing/unit-tests/ga_zeropatch2.c
+++ b/global/testing/unit-tests/ga_zeropatch2.c
@@ -16,7 +16,8 @@
 
 #define DIM 2
 #define SIZE 5
-main(int argc, char **argv)
+
+int main(int argc, char **argv)
 {
   int rank, nprocs, i, j;
   int g_A, g_B, local_A[SIZE][SIZE], local_B[SIZE][SIZE];  

--- a/global/testing/unpackc.c
+++ b/global/testing/unpackc.c
@@ -284,6 +284,9 @@ int main(int argc, char **argv)
         }
     }
 
+    if (me == 0)
+      printf("All tests successful\n");
+
     GA_Terminate();
     MP_FINALIZE();
 


### PR DESCRIPTION
1. Add missing include guard and remove duplicated `print_subscript`
2. Fix signature of `main`
3. Fix paths to test executables and change `PASS_REGULAR_EXPRESSION` to "All tests successful"
4. Add missing "All tests successful"
