### PR TITLE
Develop

### DIFF
--- a/tcgmsg/tests/test.c
+++ b/tcgmsg/tests/test.c
@@ -11,6 +11,9 @@
 #if HAVE_MEMORY_H
 #   include <memory.h>
 #endif
+#if HAVE_STRINGS_H
+#   include <strings.h>
+#endif
 #if HAVE_STDLIB_H
 #   include <stdlib.h>
 #endif

--- a/travis/install-intel.sh
+++ b/travis/install-intel.sh
@@ -28,10 +28,10 @@ case "$os" in
     Darwin)
 	mkdir -p ~/mntdmg ~/apps/oneapi || true
 	cd ~/Downloads
-	dir_base="17426"
-	dir_hpc="17398"
-	base="m_BaseKit_p_2021.1.0.2427_offline"
-	hpc="m_HPCKit_p_2021.1.0.2681_offline"
+	dir_base="17714"
+	dir_hpc="17643"
+	base="m_BaseKit_p_2021.2.0.2855_offline"
+	hpc="m_HPCKit_p_2021.2.0.2903_offline"
 	curl -LJO https://registrationcenter-download.intel.com/akdlm/irc_nas/"$dir_base"/"$base".dmg
 	curl -LJO https://registrationcenter-download.intel.com/akdlm/irc_nas/"$dir_hpc"/"$hpc".dmg
 	echo "installing BaseKit"


### PR DESCRIPTION
 * github actions on macos: update to intel oneapi 2021.2 
* added strings.h to fix clang implicit declaration error for bzero() 