### PR TITLE
fix memory leaks detected by valgrind

### DIFF
--- a/comex/src-mpi-pr/comex.c
+++ b/comex/src-mpi-pr/comex.c
@@ -748,6 +748,11 @@ int comex_finalize()
 
     free(fence_array);
 
+    free(nb_state);
+#ifdef DEBUG
+    printf(" %d freed nb_state ptr %p \n", g_state.rank, nb_state);
+#endif
+
     MPI_Barrier(g_state.comm);
 
     /* reg_cache */
@@ -3299,6 +3304,11 @@ STATIC void _progress_server()
 
 #if DEBUG_TO_FILE
     fclose(comex_trace_file);
+#endif
+
+    free(nb_state);
+#ifdef DEBUG
+    printf(" %d freed nb_state ptr %p \n", g_state.rank, nb_state);
 #endif
 
     // assume this is the end of a user's application

--- a/comex/src-mpi-pt/comex.c
+++ b/comex/src-mpi-pt/comex.c
@@ -456,6 +456,11 @@ int comex_finalize()
 
     free(fence_array);
 
+    free(nb_state);
+#ifdef DEBUG
+    printf(" %d freed nb_state ptr %p \n", g_state.rank, nb_state);
+#endif
+
     MPI_Barrier(g_state.comm);
 
     /* reg_cache */

--- a/global/src/base.c
+++ b/global/src/base.c
@@ -4131,6 +4131,9 @@ Integer i, handle;
 
     pnga_sync();
     ARMCI_Finalize();
+#ifdef MSG_COMMS_MPI
+    MPI_Comm_free(&GA_MPI_World_comm_dup);
+#endif
     ARMCIinitialized = 0;
     GAinitialized = 0;
     //GA_Internal_Threadsafe_Unlock();


### PR DESCRIPTION
* free nb_state pointer (MPI-PR and MPI-PT)
* deallocate communicator GA_MPI_World_comm_dup