### PR TITLE
initialize np to avoid garbage values in GAstat.num???_procs

### DIFF
--- a/global/src/onesided.c
+++ b/global/src/onesided.c
@@ -540,7 +540,7 @@ void ngai_put_common(Integer g_a,
 		     Integer field_size,
 		     Integer *nbhandle) 
 {
-  Integer  p, np, handle=GA_OFFSET + g_a;
+  Integer  p, np=0, handle=GA_OFFSET + g_a;
   Integer  idx, elems, size, p_handle;
   int proc, ndim, loop, cond;
   int num_loops=2; /* 1st loop for remote procs; 2nd loop for local procs */
@@ -919,7 +919,7 @@ void ngai_get_common(Integer g_a,
                       buf[]: Local buffer that array patch will be copied into
                       ld[]:  Array of physical ndim-1 dimensions of local buffer */
 
-  Integer  p, np, handle=GA_OFFSET + g_a;
+  Integer  p, np=0, handle=GA_OFFSET + g_a;
   Integer  idx, elems, size, p_handle;
   int proc, ndim, loop, cond;
   int num_loops=2; /* 1st loop for remote procs; 2nd loop for local procs */
@@ -1350,7 +1350,7 @@ void ngai_acc_common(Integer g_a,
                    void    *alpha,
                    Integer *nbhandle)
 {
-  Integer  p, np, handle=GA_OFFSET + g_a;
+  Integer  p, np=0, handle=GA_OFFSET + g_a;
   Integer  idx, elems, size, type, p_handle, ga_nbhandle;
   int optype=-1, loop, ndim, cond;
   int proc;
@@ -4233,7 +4233,7 @@ void pnga_strided_put(Integer g_a, Integer *lo, Integer *hi, Integer *skip,
      skip[]: Array of skips for each dimension
      buf[]:  Local buffer that patch will be copied from
      ld[]:   ndim-1 physical dimensions of local buffer */
-  Integer p, np, handle = GA_OFFSET + g_a;
+  Integer p, np=0, handle = GA_OFFSET + g_a;
   Integer idx, size, nstride, p_handle, nproc;
   Integer ldrem[MAXDIM];
   Integer idx_buf, *blo, *bhi;
@@ -4313,7 +4313,7 @@ void pnga_strided_get(Integer g_a, Integer *lo, Integer *hi, Integer *skip,
      skip[]: Array of skips for each dimension
      buf[]:  Local buffer that patch will be copied from
      ld[]:   ndim-1 physical dimensions of local buffer */
-  Integer p, np, handle = GA_OFFSET + g_a;
+  Integer p, np=0, handle = GA_OFFSET + g_a;
   Integer idx, size, nstride, p_handle, nproc;
   int i, proc, ndim;
   Integer ldrem[MAXDIM];
@@ -4396,7 +4396,7 @@ void pnga_strided_acc(Integer g_a, Integer *lo, Integer *hi, Integer *skip,
      buf[]:  Local buffer that patch will be copied from
      ld[]:   ndim-1 physical dimensions of local buffer
      alpha:  muliplicative scale factor */
-  Integer p, np, handle = GA_OFFSET + g_a;
+  Integer p, np=0, handle = GA_OFFSET + g_a;
   Integer idx, size, nstride, type, p_handle, nproc;
   int i, optype=-1, proc, ndim;
   Integer ldrem[MAXDIM];


### PR DESCRIPTION
some of the elements of `GAstat` struct contain nonsensical values
```
numput_procs
numget_procs
numacc_procs
numsca_procs
numgat_procs
```
The root cause of the problem in the following code in onesided.c
https://github.com/GlobalArrays/ga/blob/56443bb81df5f0e4118ca79f5aa3af30ca44ea76/global/src/onesided.c#L581

The line `GAstat.numput_procs += np;` is the culprit, since `np` is never set.

Older version of `onesided.c` got the `np` value out of `pnga_locate_region(),` but in current incarnation of onesided.c pnga_locate_region is no longer there.