### PR TITLE
fix for gcc-12 zdot issue

### DIFF
--- a/.github/workflows/github_actions.yml
+++ b/.github/workflows/github_actions.yml
@@ -34,6 +34,12 @@ jobs:
           - gcc-9
         include:
           - os: ubuntu-latest
+            experimental: true 
+            mpi_impl: mpich
+            armci_network: mpi-ts
+            f77: gfortran-11
+            cc: gcc-11
+          - os: ubuntu-latest
             experimental: true
             mpi_impl: intel
             armci_network: sockets
@@ -140,6 +146,7 @@ jobs:
           case "${{ matrix.os }}" in
           ubuntu*|jessie|stretch|buster)
           sudo apt-get update -q -y
+          if [[ "$FC" == "gfortran-11" ]] || [[ "$CC" == "gcc-11" ]]; then sudo add-apt-repository -y ppa:ubuntu-toolchain-r/test && sudo apt-get -y install gcc-11 gfortran-11 g++-11; fi
           sudo apt-get install -q -y gfortran
           ;;
           macos*)

--- a/configure.ac
+++ b/configure.ac
@@ -354,6 +354,7 @@ GA_F77_FIXED
 GA_F77_MISMATCH_TYPE
 GA_F77_INTEGER_SIZE
 GA_GNU_LOOP_OPT
+GA_F77_LOOP
 
 # Checks for Fortran typedefs, structures, and compiler characteristics.
 AC_OPENMP

--- a/global/src/scalapack.F
+++ b/global/src/scalapack.F
@@ -3605,7 +3605,7 @@ c     broadcast evals
 #endif
 #endif
       implicit none
-#include "mpif.h"
+c#include "mpif.h"
 #include "mafdecls.fh"
 #include "global.fh"
 #include "scalapack.fh"

--- a/m4/ga_f77_loop.m4
+++ b/m4/ga_f77_loop.m4
@@ -1,0 +1,25 @@
+# GA_F77_LOOP
+# ------------
+# enables -fno-tree-no-vectorize to avoid loop issues in global/testing/test.F
+# since gfortran 12 uses -fno-tree-no-vectorize at -O2 level
+# https://github.com/GlobalArrays/ga/issues/249
+#
+AC_DEFUN([GA_F77_LOOP], [
+AC_CACHE_CHECK([whether $F77 needs a flag to disable fortran loop vectorization],
+[ga_cv_f77_loop_flag],
+[AC_LANG_PUSH([Fortran 77])
+for testflag in -fno-tree-vectorize; do
+    ga_save_FFLAGS=$FFLAGS
+    AS_IF([test "x$testflag" != xnone], [FFLAGS="$FFLAGS $testflag"])
+    AC_COMPILE_IFELSE([AC_LANG_SOURCE(
+[[c some comment
+      end program]])],
+        [ga_cv_f77_loop_flag=$testflag])
+    FFLAGS=$ga_save_FFLAGS
+    AS_IF([test "x$ga_cv_f77_loop_flag" != x], [break])
+done
+AC_LANG_POP([Fortran 77])])
+AS_IF([test "x$ga_cv_f77_loop_flag" != xnone],
+    [AS_IF([test "x$ga_cv_f77_loop_flag" != x],
+        [FFLAGS="$FFLAGS $ga_cv_f77_loop_flag"])])
+]) # GA_F77_LOOP

--- a/m4/ga_f77_loop.m4
+++ b/m4/ga_f77_loop.m4
@@ -1,14 +1,14 @@
 # GA_F77_LOOP
 # ------------
-# enables -fno-tree-no-vectorize to avoid loop issues in global/testing/test.F
-# since gfortran 12 uses -fno-tree-no-vectorize at -O2 level
+# enables -fno-tree-slp-vectorize to avoid failures in global/testing/test.F
+# since gfortran 12 uses -ftree-vectorize at -O2 level
 # https://github.com/GlobalArrays/ga/issues/249
 #
 AC_DEFUN([GA_F77_LOOP], [
 AC_CACHE_CHECK([whether $F77 needs a flag to disable fortran loop vectorization],
 [ga_cv_f77_loop_flag],
 [AC_LANG_PUSH([Fortran 77])
-for testflag in -fno-tree-vectorize; do
+for testflag in -fno-tree-slp-vectorize; do
     ga_save_FFLAGS=$FFLAGS
     AS_IF([test "x$testflag" != xnone], [FFLAGS="$FFLAGS $testflag"])
     AC_COMPILE_IFELSE([AC_LANG_SOURCE(


### PR DESCRIPTION
* added gfortran `-fno-tree-vectorize` flag to address https://github.com/GlobalArrays/ga/issues/249
* added gcc-11 github actions test