### PR TITLE
deallocate strdup malloc

### DIFF
--- a/tcgmsg/fapi.c
+++ b/tcgmsg/fapi.c
@@ -200,6 +200,7 @@ void FATR _PBEGINF_()
 
     argv[argc] = 0;
     tcgi_pbegin(argc, argv);
+    for (i=0; i<argc; i++) free(argv[i]);
     free(argv);
 }
 


### PR DESCRIPTION
memory leak spotted by https://github.com/google/sanitizers/wiki/AddressSanitizer