### PR TITLE
Fix gethostid returning the same val on different hosts

### DIFF
--- a/comex/src-mpi-mt/groups.c
+++ b/comex/src-mpi-mt/groups.c
@@ -2,6 +2,7 @@
 #   include "config.h"
 #endif
 
+#include <fcntl.h>
 #include <stdlib.h>
 #include <string.h>
 #include <stdio.h>
@@ -470,48 +471,101 @@ void comex_group_finalize()
 }
 
 
-static long xgethostid()
-{
 #if defined(__bgp__)
 #warning BGP
-    long nodeid;
+
+static long xgethostid()
+{
     int matched,midplane,nodecard,computecard;
+    _BGP_Personality_t personality;
     char rack_row,rack_col;
     char location[128];
     char location_clean[128];
+
     (void) memset(location, '\0', 128);
     (void) memset(location_clean, '\0', 128);
-    _BGP_Personality_t personality;
+
     Kernel_GetPersonality(&personality, sizeof(personality));
     BGP_Personality_getLocationString(&personality, location);
+
     matched = sscanf(location, "R%c%c-M%1d-N%2d-J%2d",
             &rack_row, &rack_col, &midplane, &nodecard, &computecard);
+
     COMEX_ASSERT(matched == 5);
+
     sprintf(location_clean, "%2d%02d%1d%02d%02d",
             (int)rack_row, (int)rack_col, midplane, nodecard, computecard);
-    nodeid = atol(location_clean);
+
+    return atol(location_clean);
+}
+
 #elif defined(__bgq__)
 #warning BGQ
-    int nodeid;
+
+static long xgethostid()
+{
     MPIX_Hardware_t hw;
+
     MPIX_Hardware(&hw);
 
-    nodeid = hw.Coords[0] * hw.Size[1] * hw.Size[2] * hw.Size[3] * hw.Size[4]
-        + hw.Coords[1] * hw.Size[2] * hw.Size[3] * hw.Size[4]
-        + hw.Coords[2] * hw.Size[3] * hw.Size[4]
-        + hw.Coords[3] * hw.Size[4]
-        + hw.Coords[4];
+    return hw.Coords[0] * hw.Size[1] * hw.Size[2] * hw.Size[3] * hw.Size[4] +
+           hw.Coords[1] * hw.Size[2] * hw.Size[3] * hw.Size[4] +
+           hw.Coords[2] * hw.Size[3] * hw.Size[4] +
+           hw.Coords[3] * hw.Size[4] +
+           hw.Coords[4];
+}
+
 #elif defined(__CRAYXT) || defined(__CRAYXE)
 #warning CRAY
-    int nodeid;
+
+static long xgethostid()
+{
+    long nodeid;
+
 #  if defined(__CRAYXT)
     PMI_Portals_get_nid(g_state.rank, &nodeid);
 #  elif defined(__CRAYXE)
     PMI_Get_nid(g_state.rank, &nodeid);
 #  endif
-#else
-    long nodeid = gethostid();
-#endif
 
     return nodeid;
 }
+
+#else
+
+static long xgethostid(void)
+{
+    const char *src[] = {
+        "/etc/hostid",
+        "/etc/machine-id",
+        NULL
+    };
+    char data[32] = {0};
+    long nodeid = 0;
+    ssize_t n;
+    int i, fd;
+
+    for (i = 0; src[i]; ++i) {
+        fd = open(src[i], O_RDONLY | O_LARGEFILE, 0);
+        if (fd >= 0)
+            break;
+    }
+
+    if (fd < 0)
+        return gethostid();
+
+    n = read(fd, &data, sizeof(data));
+    close(fd);
+
+    if (n < 0) {
+        perror("xgethostid: read(id)");
+        comex_error("xgethostid: Failed on hostid reading", n);
+    }
+
+    for (i = 0; i < n; i += sizeof(long))
+        nodeid ^= *(long *)&data[i];
+
+    return nodeid;
+}
+
+#endif

--- a/comex/src-mpi-pt/groups.c
+++ b/comex/src-mpi-pt/groups.c
@@ -2,6 +2,7 @@
 #   include "config.h"
 #endif
 
+#include <fcntl.h>
 #include <stdlib.h>
 #include <string.h>
 #include <stdio.h>
@@ -506,48 +507,101 @@ void comex_group_finalize()
 }
 
 
-static long xgethostid()
-{
 #if defined(__bgp__)
 #warning BGP
-    long nodeid;
+
+static long xgethostid()
+{
     int matched,midplane,nodecard,computecard;
+    _BGP_Personality_t personality;
     char rack_row,rack_col;
     char location[128];
     char location_clean[128];
+
     (void) memset(location, '\0', 128);
     (void) memset(location_clean, '\0', 128);
-    _BGP_Personality_t personality;
+
     Kernel_GetPersonality(&personality, sizeof(personality));
     BGP_Personality_getLocationString(&personality, location);
+
     matched = sscanf(location, "R%c%c-M%1d-N%2d-J%2d",
             &rack_row, &rack_col, &midplane, &nodecard, &computecard);
+
     COMEX_ASSERT(matched == 5);
+
     sprintf(location_clean, "%2d%02d%1d%02d%02d",
             (int)rack_row, (int)rack_col, midplane, nodecard, computecard);
-    nodeid = atol(location_clean);
+
+    return atol(location_clean);
+}
+
 #elif defined(__bgq__)
 #warning BGQ
-    int nodeid;
+
+static long xgethostid()
+{
     MPIX_Hardware_t hw;
+
     MPIX_Hardware(&hw);
 
-    nodeid = hw.Coords[0] * hw.Size[1] * hw.Size[2] * hw.Size[3] * hw.Size[4]
-        + hw.Coords[1] * hw.Size[2] * hw.Size[3] * hw.Size[4]
-        + hw.Coords[2] * hw.Size[3] * hw.Size[4]
-        + hw.Coords[3] * hw.Size[4]
-        + hw.Coords[4];
+    return hw.Coords[0] * hw.Size[1] * hw.Size[2] * hw.Size[3] * hw.Size[4] +
+           hw.Coords[1] * hw.Size[2] * hw.Size[3] * hw.Size[4] +
+           hw.Coords[2] * hw.Size[3] * hw.Size[4] +
+           hw.Coords[3] * hw.Size[4] +
+           hw.Coords[4];
+}
+
 #elif defined(__CRAYXT) || defined(__CRAYXE)
 #warning CRAY
-    int nodeid;
+
+static long xgethostid()
+{
+    long nodeid;
+
 #  if defined(__CRAYXT)
     PMI_Portals_get_nid(g_state.rank, &nodeid);
 #  elif defined(__CRAYXE)
     PMI_Get_nid(g_state.rank, &nodeid);
 #  endif
-#else
-    long nodeid = gethostid();
-#endif
 
     return nodeid;
 }
+
+#else
+
+static long xgethostid(void)
+{
+    const char *src[] = {
+        "/etc/hostid",
+        "/etc/machine-id",
+        NULL
+    };
+    char data[32] = {0};
+    long nodeid = 0;
+    ssize_t n;
+    int i, fd;
+
+    for (i = 0; src[i]; ++i) {
+        fd = open(src[i], O_RDONLY | O_LARGEFILE, 0);
+        if (fd >= 0)
+            break;
+    }
+
+    if (fd < 0)
+        return gethostid();
+
+    n = read(fd, &data, sizeof(data));
+    close(fd);
+
+    if (n < 0) {
+        perror("xgethostid: read(id)");
+        comex_error("xgethostid: Failed on hostid reading", n);
+    }
+
+    for (i = 0; i < n; i += sizeof(long))
+        nodeid ^= *(long *)&data[i];
+
+    return nodeid;
+}
+
+#endif


### PR DESCRIPTION
It's possible to have the HPC host IDs improperly initialized. In that
case the gethostid() method may return the same values on different hosts
causing the GA runtime error like:

> _malloc_semaphore: sem_open: No such file or directory
> [0] Received an Error in Communication: (-2) _malloc_semaphore: sem_open

One of our systems has that misbehaviour caused by the /etc/hostid
file initialized with 8-chars string differing only in the tail four chars
while the gethostid() reads the first four bytes only expecting
them to indicate an unique host ID. As a result the Global Arrays MPI
PT/PR/MT setups failed to run on greater than one cluster node.

We suggest to fix it by locally reading the hostid content and by taking
the whole string (up to 32 bytes) into account when calculating the host
IDs detected on the nodes involved in the GA communications. If there is
no /etc/hostid file found the /etc/machine-id file will be used (it's
initialized by systemd on the hosts bootup procedure). If none of these
files is detected then the gethostid() method will be utilized, which aside
with checking the /etc/hostid file availability will try to calculate the
IP-address-based host ID.

Note this change has been tested on the system with 8-chars long /etc/hostid
content and GA built with --with-mpi-pt and --with-mpi-pr parameters.