### PR TITLE
allow ARMCI_VERBOSE to enable debug printing at runtime

### DIFF
--- a/comex/src-mpi-pr/comex.c
+++ b/comex/src-mpi-pr/comex.c
@@ -379,6 +379,8 @@ int comex_init()
 
     /* env vars */
     {
+        int armci_verbose;
+
         char *value = NULL;
         nb_max_outstanding = COMEX_MAX_NB_OUTSTANDING; /* default */
         value = getenv("COMEX_MAX_NB_OUTSTANDING");
@@ -503,7 +505,16 @@ int comex_init()
         }
 
 #if DEBUG
-        if (0 == g_state.rank) {
+        armci_verbose = 1;
+#else
+        armci_verbose = 0;
+#endif
+        value = getenv("ARMCI_VERBOSE");
+        if (NULL != value) {
+            armci_verbose = atoi(value);
+        }
+
+        if (armci_verbose && 0 == g_state.rank) {
             printf("COMEX_MAX_NB_OUTSTANDING=%d\n", nb_max_outstanding);
             printf("COMEX_STATIC_BUFFER_SIZE=%d\n", static_server_buffer_size);
             printf("COMEX_MAX_MESSAGE_SIZE=%d\n", max_message_size);
@@ -526,7 +537,6 @@ int comex_init()
             printf("COMEX_ENABLE_ACC_IOV=%d\n", COMEX_ENABLE_ACC_IOV);
             fflush(stdout);
         }
-#endif
     }
 
     /* mutexes */

--- a/comex/src-mpi3/comex.c
+++ b/comex/src-mpi3/comex.c
@@ -207,6 +207,9 @@ int comex_init()
 
     /* Pick up environment variables */
     {
+      int armci_verbose;
+      int me;
+
       char *value = NULL;
       nb_max_outstanding = COMEX_MAX_NB_OUTSTANDING; /* default */
       value = getenv("COMEX_MAX_NB_OUTSTANDING");
@@ -214,6 +217,22 @@ int comex_init()
         nb_max_outstanding = atoi(value);
       }
       COMEX_ASSERT(nb_max_outstanding > 0);
+
+#if DEBUG
+      armci_verbose = 1;
+#else
+      armci_verbose = 0;
+#endif
+      value = getenv("ARMCI_VERBOSE");
+      if (NULL != value) {
+          armci_verbose = atoi(value);
+      }
+
+      if (armci_verbose && 0 == l_state.rank) {
+            printf("COMEX_MAX_NB_OUTSTANDING=%d\n", nb_max_outstanding);
+            fflush(stdout);
+      }
+
     }
 
     

--- a/travis/install-intel.sh
+++ b/travis/install-intel.sh
@@ -68,4 +68,9 @@ case "$os" in
 	    && sudo apt-get -y install intel-oneapi-ifort intel-oneapi-compiler-dpcpp-cpp-and-cpp-classic  intel-oneapi-mkl \
 	    && sudo apt-get -y install intel-oneapi-mpi-devel
 	source "$IONEAPI_ROOT"/setvars.sh --force || true
+	which mpif90
+	mpif90 -show
 esac
+which ifort
+ifort -V
+echo ""##### end of  install-intel.sh ####"


### PR DESCRIPTION
ARMCI-MPI uses `ARMCI_VERBOSE=1` to dump config details at runtime.  ComEx has similar config details but currently requires one to compile with the `DEBUG` preprocessor symbol to enable them.  This adds support to enable this at runtime for MPI-PR and MPI-3 ComEx back-ends.