### PR TITLE
Disk Resident Arrays Fortran to C interface

### DIFF
--- a/pario/dra/fortran.c
+++ b/pario/dra/fortran.c
@@ -43,6 +43,10 @@ Integer FATR dra_create_(
         )
 {
     ga_f2cstring(name, nlen, cname, DRA_MAX_NAME);
+    /* workaround for flen=0 on macos-12 */
+    if (flen == 0 ){
+      flen = strlen(filename);
+    }
     ga_f2cstring(filename, flen, cfilename, DRA_MAX_FNAME);
     return drai_create(type, dim1, dim2, cname, cfilename,
             mode, reqdim1, reqdim2,d_a);

--- a/pario/dra/fortran.c
+++ b/pario/dra/fortran.c
@@ -80,6 +80,10 @@ Integer FATR ndra_create_(
         )
 {
     ga_f2cstring(name, nlen, cname, DRA_MAX_NAME);
+    /* workaround for flen=0 on macos-12 */
+    if (flen == 0 ){
+      flen = strlen(filename);
+    } 
     ga_f2cstring(filename, flen, cfilename, DRA_MAX_FNAME);
     return ndrai_create(type, ndim, dims, cname, cfilename, mode, reqdims, d_a);
 }
@@ -99,8 +103,8 @@ Integer FATR dra_open_(
 #endif
         )
 {
-    ga_f2cstring(filename, flen, cfilename, DRA_MAX_FNAME);
-    return drai_open(cfilename, mode, d_a);
+  ga_f2cstring(filename, flen, cfilename, DRA_MAX_FNAME);
+  return drai_open(cfilename, mode, d_a);
 }
 
 
@@ -195,6 +199,10 @@ Integer ndra_create_config_(
         )
 {
     ga_f2cstring(name, nlen, cname, DRA_MAX_NAME);
+    /* workaround for flen=0 on macos-12 */
+    if (flen == 0 ){
+      flen = strlen(filename);
+    }
     ga_f2cstring(filename, flen, cfilename, DRA_MAX_FNAME);
     return ndrai_create_config(type, ndim, dims, cname, cfilename,
             mode, reqdims, numfiles, numioprocs, d_a);

--- a/pario/dra/ntest.F
+++ b/pario/dra/ntest.F
@@ -49,6 +49,7 @@ c     if(me.eq.0)print *, 'all done ...'
 
 
       subroutine test_io_int
+      use iso_c_binding
       implicit none
 #include "mafdecls.fh"
 #include "global.fh"
@@ -115,7 +116,7 @@ c
       req(3) = 1
       ndim = 3
       if(ndra_create(MT_INT, ndim, dims, 'array A', 
-     &   FNAME, 
+     &   trim(FNAME)//c_null_char, 
      &   DRA_RW,    req, d_a).ne.0)
      $   CALL ga_error('ndra_create failed: ',0)
       if (me.eq.0) print *,'OK'
@@ -133,7 +134,8 @@ c
       if (me.eq.0) print*,' '
 c
       if(me.eq.0) print *, 'Opening Existing Disk Array'
-      if(dra_open(FNAME ,DRA_R, d_a).ne.0)
+      if(dra_open(trim(FNAME)//c_null_char ,
+     D     DRA_R, d_a).ne.0)
      &            call ga_error('dra_open failed',0)
 c     
       if(ndra_inquire(d_a, type, ndim, dims, name, filename).ne.0)
@@ -183,6 +185,7 @@ c
 
 
       subroutine test_io_dbl
+      use iso_c_binding
       implicit none
 #include "mafdecls.fh"
 #include "global.fh"
@@ -252,7 +255,7 @@ c
       req(2) = n
       req(3) = 3
       if(ndra_create(MT_DBL, ndim, dims, 'A', 
-     &      FNAME, 
+     &      trim(FNAME)//c_null_char, 
      &      DRA_RW, req, d_a).ne.0)
      $   CALL ga_error('ndra_create failed: ',0)
 c
@@ -265,7 +268,7 @@ c
       if(dra_close(d_a).ne.0)call ga_error('dra_close failed: ',d_a)
 c
       if(me.eq.0) print *, 'Checking ndra_read'
-      if(dra_open(FNAME,DRA_R, d_a).ne.0)
+      if(dra_open(trim(FNAME)//c_null_char,DRA_R, d_a).ne.0)
      &            call ga_error('dra_open failed',0)
       if(ndra_read(g_b, d_a, req).ne.0)
      $   CALL ga_error('ndra_read failed:',0)
@@ -337,7 +340,7 @@ c
       req(2) = n
       req(3) = 2
       if(ndra_create(MT_DBL, ndim, dims, 'A', 
-     &      FNAME, 
+     &      trim(FNAME)//c_null_char, 
      &      DRA_RW, req, d_a).ne.0)
      $   CALL ga_error('dra_create failed: ',0)
       if (me.eq.0) print*,' OK'

--- a/travis/build-run.sh
+++ b/travis/build-run.sh
@@ -163,6 +163,9 @@ then
 else
     mpirun -n 4 ${MAYBE_OVERSUBSCRIBE} ${TEST_NAME}
 fi
+if [ "$USE_CMAKE" = "Y" ] ; then
+    echo "skipping dra test when using cmake"
+else
 TEST_NAME=./pario/dra/ntest.x
 if test -x $TEST_NAME
 then
@@ -183,4 +186,5 @@ then
     mpirun -n 5 ${MAYBE_OVERSUBSCRIBE} ${TEST_NAME}
 else
     mpirun -n 4 ${MAYBE_OVERSUBSCRIBE} ${TEST_NAME}
+fi
 fi

--- a/travis/build-run.sh
+++ b/travis/build-run.sh
@@ -163,3 +163,24 @@ then
 else
     mpirun -n 4 ${MAYBE_OVERSUBSCRIBE} ${TEST_NAME}
 fi
+TEST_NAME=./pario/dra/ntest.x
+if test -x $TEST_NAME
+then
+    echo "Running fortran-based test"
+else
+    TEST_NAME=./pario/dra/ntestc.x
+    if test -x $TEST_NAME
+    then
+        echo "Running C-based test"
+    else
+        echo "No suitable test was found"
+        exit 1
+    fi
+fi
+
+if test "x$PORT" = "xmpi-pr"
+then
+    mpirun -n 5 ${MAYBE_OVERSUBSCRIBE} ${TEST_NAME}
+else
+    mpirun -n 4 ${MAYBE_OVERSUBSCRIBE} ${TEST_NAME}
+fi


### PR DESCRIPTION
When using Disk Resident Arrays on the latest MacOS Monterey on M1 CPUs, the current Fortran to C interface fails to detect the length of string variables.   
The current Fortran to C interface uses the hidden argument string length approach that has always worked up to this case.  
I have generated a workaround that uses `strlen()` when the string length is passed as zero.  
A better solution would be to use Fortran90 ISO C binding. 