### PR TITLE
fix preprocessing define for  freed nb_state ptr warning

### DIFF
--- a/comex/src-mpi-pt/comex.c
+++ b/comex/src-mpi-pt/comex.c
@@ -457,7 +457,7 @@ int comex_finalize()
     free(fence_array);
 
     free(nb_state);
-#ifdef DEBUG
+#if DEBUG
     printf(" %d freed nb_state ptr %p \n", g_state.rank, nb_state);
 #endif
 


### PR DESCRIPTION
Removes `freed nb_state ptr` message from showing up at the end of each run when using MPI-PT