### PR TITLE
bring back ga_deallocate  

### DIFF
--- a/global/src/global.fh.in
+++ b/global/src/global.fh.in
@@ -3,6 +3,7 @@
       parameter (ga_max_dim = GA_MAX_DIM)
 !
       logical          ga_allocate
+      logical          ga_deallocate
       complex          ga_cdot
       complex          ga_cdot_patch
       integer          ga_cluster_nnodes
@@ -71,6 +72,7 @@
       double complex   ga_zdot
       double complex   ga_zdot_patch
       logical          nga_allocate
+      logical          nga_deallocate
       complex          nga_cdot
       complex          nga_cdot_patch
       integer          nga_cluster_nnodes
@@ -154,6 +156,7 @@
       double complex   nga_zdot_patch
 !
       external ga_allocate
+      external ga_deallocate
       external ga_cdot
       external ga_cdot_patch
       external ga_cluster_nnodes
@@ -222,6 +225,7 @@
       external ga_zdot
       external ga_zdot_patch
       external nga_allocate
+      external nga_deallocate
       external nga_cdot
       external nga_cdot_patch
       external nga_cluster_nnodes


### PR DESCRIPTION
the definitions of ga_allocate() and nga_deallocate() were removed  by commit 68abe1350a9ecf6cca9866dee92dc5e7e443089d