### PR TITLE
Fix missing symbols

### DIFF
--- a/comex/src-mpi-pr/dev_utils_hip.cpp
+++ b/comex/src-mpi-pr/dev_utils_hip.cpp
@@ -271,7 +271,7 @@ void deviceIaxpy(int *dst, int *src, const int *scale, int n)
     hipPointerAttribute_t src_attr;
     hipPointerAttribute_t dst_attr;
     hipError_t  perr = hipPointerGetAttributes(&src_attr, src);
-    if (perr != hipSuccess || src_attr.memoryType != hipMemoryTypeDevice {
+    if (perr != hipSuccess || src_attr.memoryType != hipMemoryTypeDevice) {
       printf("p[%d] deviceIaxpy src pointer is on host\n",rank);
     } else if (src_attr.memoryType == hipMemoryTypeDevice)  {
       printf("p[%d] deviceIaxpy src pointer is on device %d\n",rank,src_attr.device);

--- a/comex/src-mpi-pr/dev_utils_hip.cpp
+++ b/comex/src-mpi-pr/dev_utils_hip.cpp
@@ -157,7 +157,7 @@ void copyToDevice(void *devptr, void *hostptr, int bytes)
  */
 void copyToHost(void *hostptr, void *devptr, int bytes)
 {
-  hipError_t ierr = hipMemcpy(hostptr, devptr, bytes, hipMemcpyDeviceToHost); 
+  hipError_t ierr = hipMemcpy(hostptr, devptr, bytes, hipMemcpyDeviceToHost);
   hipErrCheck(ierr);
   if (ierr != hipSuccess) {
     hipPointerAttribute_t src_attr, dst_attr;
@@ -197,7 +197,7 @@ void copyToHost(void *hostptr, void *devptr, int bytes)
 void copyDevToDev(void *dstptr, void *srcptr, int bytes)
 {
   hipError_t ierr;
-  ierr = hipMemcpy(dstptr, srcptr, bytes, hipMemcpyDeviceToDevice); 
+  ierr = hipMemcpy(dstptr, srcptr, bytes, hipMemcpyDeviceToDevice);
   hipErrCheck(ierr);
   hipDeviceSynchronize();
   if (ierr != hipSuccess) {


### PR DESCRIPTION
This adds HIP ports for strided kernels and the `parallel(Memcpy|Accumulate)` functions.

I have not checked correctness for the strided kernels, simply ported their cuda variants in order for the ga to link successfully.

I need ga to link successfully in order to diagnose a separate p2p correctness bug I am currently chasing.