### PR TITLE
Make device utility function decls visible to HIP

### DIFF
--- a/comex/src-mpi-pr/dev_utils.h
+++ b/comex/src-mpi-pr/dev_utils.h
@@ -6,8 +6,6 @@
 
 #if defined(ENABLE_DEVICE)
 
-
-#if defined(ENABLE_CUDA)
 extern int numDevices();
 extern void setDevice(int id);
 extern void mallocDevice(void **buf, int size);
@@ -32,10 +30,6 @@ extern void parallelAccumulate(int op, void *src, int *src_stride, void *dst, in
 
 extern int _comex_dev_flag;
 extern int _comex_dev_id;
-
-// #elif defined(ENABLE_HIP)
-// #include "dev_utils_hip.hpp"
-#endif
 
 /**
  * Skip the intense macro usage and just do this the old-fashion way

--- a/comex/src-mpi-pr/groups.c
+++ b/comex/src-mpi-pr/groups.c
@@ -24,6 +24,8 @@
 #include "comex_impl.h"
 #include "groups.h"
 
+#include "dev_utils.h"
+
 
 /* world group state */
 comex_group_world_t g_state = {


### PR DESCRIPTION
Newer ROCm compilers appear to have stricter ISO C99 compliance checks, and implicit function declarations are now compiler errors.

This change makes the declarations visible to the HIP backend.