### PR TITLE
Fix default compiler options

### DIFF
--- a/cmake/ga-compiler-options.cmake
+++ b/cmake/ga-compiler-options.cmake
@@ -7,7 +7,6 @@ if(CMAKE_C_COMPILER_ID MATCHES "Clang" OR CMAKE_C_COMPILER_ID MATCHES "IntelLLVM
   else()
     string( TOUPPER ${CMAKE_BUILD_TYPE} __cmbt_upper )
   endif()
-  set(CMAKE_C_FLAGS_${__cmbt_upper} "-O3 -g")
 endif()
 
 if(CMAKE_C_COMPILER_ID STREQUAL "Clang" OR CMAKE_C_COMPILER_ID STREQUAL "IntelLLVM")


### PR DESCRIPTION
This can step on attempts by the user to set their own compiler optimisation and debugging symbol flags via CMAKE_(C|CXX)_FLAGS.