### PR TITLE
GitHub actions fixes for master

### DIFF
--- a/.github/workflows/github_actions.yml
+++ b/.github/workflows/github_actions.yml
@@ -183,10 +183,12 @@ jobs:
           pwd
           ls -lart
           mkdir -p $GITHUB_WORKSPACE/apps
+          if [[ "$F77" == "ifort" ]] || [[ "$CC" == "icc" ]] ; then ./travis/install-intel.sh; source ${{ matrix.oneapi }}/setvars.sh --force;  fi
           sh ./travis/install-autotools.sh $GITHUB_WORKSPACE/apps
       - name: install
         run: |
           export CI_ROOT=$GITHUB_WORKSPACE/apps
+          if [[ "$F77" == "ifort" ]] || [[ "$CC" == "icc" ]] ; then ./travis/install-intel.sh; source ${{ matrix.oneapi }}/setvars.sh --force;  fi
           ./travis/install-mpi.sh $CI_ROOT $MPI_IMPL
           if [[ "$PORT" == "ofi" ]]; then ./travis/install-libfabric.sh $CI_ROOT; else true;  fi
           if [[ "$PORT" == "armci" ]]; then ./travis/install-armci-mpi.sh $CI_ROOT; else true; fi
@@ -194,6 +196,7 @@ jobs:
       - name: compile and test global arrays
         if: ${{ success() }}
         run: |
+          if [[ "$F77" == "ifort" ]] || [[ "$CC" == "icc" ]] ; then ./travis/install-intel.sh; source ${{ matrix.oneapi }}/setvars.sh --force;  fi
           ./travis/build-run.sh $GITHUB_WORKSPACE/apps $PORT $MPI_IMPL $USE_CMAKE $F77
       - name: after_failure
         if: ${{ failure() }}

--- a/.github/workflows/github_actions.yml
+++ b/.github/workflows/github_actions.yml
@@ -197,7 +197,7 @@ jobs:
         if: ${{ success() }}
         run: |
           if [[ "$F77" == "ifort" ]] || [[ "$CC" == "icc" ]] ; then ./travis/install-intel.sh; source ${{ matrix.oneapi }}/setvars.sh --force;  fi
-          FC="$F77" CC="$CC"./travis/build-run.sh $GITHUB_WORKSPACE/apps $PORT $MPI_IMPL $USE_CMAKE $F77
+          FC="$F77" CC="$CC" ./travis/build-run.sh $GITHUB_WORKSPACE/apps $PORT $MPI_IMPL $USE_CMAKE $F77
       - name: after_failure
         if: ${{ failure() }}
         run: |

--- a/.github/workflows/github_actions.yml
+++ b/.github/workflows/github_actions.yml
@@ -197,7 +197,7 @@ jobs:
         if: ${{ success() }}
         run: |
           if [[ "$F77" == "ifort" ]] || [[ "$CC" == "icc" ]] ; then ./travis/install-intel.sh; source ${{ matrix.oneapi }}/setvars.sh --force;  fi
-          ./travis/build-run.sh $GITHUB_WORKSPACE/apps $PORT $MPI_IMPL $USE_CMAKE $F77
+          FC="$F77" CC="$CC"./travis/build-run.sh $GITHUB_WORKSPACE/apps $PORT $MPI_IMPL $USE_CMAKE $F77
       - name: after_failure
         if: ${{ failure() }}
         run: |

--- a/.github/workflows/github_actions.yml
+++ b/.github/workflows/github_actions.yml
@@ -32,6 +32,8 @@ jobs:
         cc:
           - clang
           - gcc
+        use_cmake:
+          - "N"
         include:
           - os: ubuntu-latest
             experimental: true
@@ -39,6 +41,7 @@ jobs:
             armci_network: mpi-ts
             f77: gfortran-11
             cc: gcc-11
+            use_cmake: "N"
           - os: ubuntu-20.04
             experimental: true
             mpi_impl: mpich
@@ -50,9 +53,11 @@ jobs:
             experimental: true
             mpi_impl: intel
             armci_network: sockets
-            config_opts: --enable-i4 --with-blas=-lmkl_rt --with-scalapack=-lmkl_scalapack_lp64
+            config_opts: --enable-i4
             f77: ifort
-            cc: gcc
+            cc: icc
+            oneapi: /opt/intel/oneapi
+            use_cmake: "N"
           - os: ubuntu-latest
             experimental: true
             mpi_impl: openmpi
@@ -60,12 +65,15 @@ jobs:
             config_opts: --enable-i4 --without-blas --enable-cxx --disable-f77
             f77: gfortran
             cc: gcc
+            use_cmake: "N"
           - os: macos-11
             experimental: true
             mpi_impl: mpich
             armci_network: mpi-pr
             f77: ifort
             cc: icc
+            oneapi: /Users/runner/apps/oneapi
+            use_cmake: "N"
           - os: ubuntu-20.04
             experimental: true 
             mpi_impl: mpich
@@ -73,6 +81,7 @@ jobs:
             f77: gfortran
             cc: gcc
             use_sicm: "Y"
+            use_cmake: "N"
           - os: ubuntu-22.04
             experimental: true 
             mpi_impl: mpich
@@ -80,6 +89,7 @@ jobs:
             config_opts: "--disable-f77 --enable-cxx"
             f77: gfortran-10
             cc: gcc-10
+            use_cmake: "N"
           - os: macos-12
             experimental: true 
             mpi_impl: mpich
@@ -87,33 +97,36 @@ jobs:
             config_opts: "--disable-static --enable-shared"
             f77: gfortran
             cc: clang
+            use_cmake: "N"
           - os: macos-12
             experimental: true
-            use_cmake: "Y"
             mpi_impl: mpich
             armci_network: mpi-pr
             f77: gfortran
             cc: clang
+            use_cmake: "Y"
           - os: ubuntu-20.04
             experimental: true
-            use_cmake: "Y"
             mpi_impl: openmpi
             armci_network: mpi-pr
             f77: gfortran
             cc: gcc
+            use_cmake: "Y"
           - os: ubuntu-20.04
             experimental: true
-            use_cmake: "Y"
             mpi_impl: openmpi
             armci_network: mpi-ts
             f77: gfortran
             cc: gcc
+            use_cmake: "Y"
           - os: ubuntu-20.04
             experimental: true
             mpi_impl: intel
             armci_network: mpi-ts
             f77: ifort
             cc: gcc
+            oneapi: /opt/intel/oneapi
+            use_cmake: "N"
         exclude:
           - armci_network: mpi-pr
             mpi_impl: openmpi
@@ -134,12 +147,12 @@ jobs:
     continue-on-error: ${{ matrix.experimental }}
     steps: 
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           fetch-depth: 40
       - name: Cache install steps
         id: ga-cache-install
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         env:
           cache-name: cache-install-steps
         with:
@@ -161,9 +174,9 @@ jobs:
           brew install gcc coreutils automake || true
           ;;
           esac
-          if [[ "$FC" == "ifort" ]] || [[ "$CC" == "icc" ]] ; then ./travis/install-intel.sh; else true;  fi
-          echo FC is `which "$FC"`
-          echo FC compiler version `"$FC" -v`
+          if [[ "$F77" == "ifort" ]] || [[ "$CC" == "icc" ]] ; then ./travis/install-intel.sh; source ${{ matrix.oneapi }}/setvars.sh --force;  fi
+          echo F77 is `which "$F77"`
+          echo F77 compiler version `"$F77" -v`
       - name: before_install
         if: steps.ga-cache-install.outputs.cache-hit != 'true'
         run: |

--- a/travis/build-run.sh
+++ b/travis/build-run.sh
@@ -114,8 +114,13 @@ case "x$PORT" in
         ;;
     x*)
 	if [[ "$MPI_IMPL" = "intel" ]] ; then
+	    export I_MPI_F90="$F77"
+	    export I_MPI_F77="$F77"
+	    export I_MPI_CC="$CC"
 	    #hack to get scalapack going
-	    ./configure --with-${PORT} ${CONFIG_OPTS} LIBS=" -L${MKLROOT}/lib/intel64 -lmkl_scalapack_lp64 -lmkl_intel_lp64 -lmkl_sequential -lmkl_core -lmkl_blacs_intelmpi_lp64 -lpthread -lm -ldl" CC=icc
+	    export CONFIG_OPTS2=--with-blas="-L${MKLROOT}/lib/intel64 -lmkl_intel_lp64 -lmkl_sequential -lmkl_core -lpthread -lm -ldl"
+	    export CONFIG_OPTS3=--with-scalapack="-L${MKLROOT}/lib/intel64 -lmkl_scalapack_lp64 -lmkl_intel_lp64 -lmkl_sequential -lmkl_core -lmkl_blacs_intelmpi_lp64 -lpthread -lm -ldl"
+	    ./configure --with-${PORT} ${CONFIG_OPTS} "$CONFIG_OPTS2" "$CONFIG_OPTS3" FFLAGS=-fPIC
 	else
             ./configure --with-${PORT} ${CONFIG_OPTS}
 	fi


### PR DESCRIPTION
Since all the branches are using the workflow definition https://github.com/GlobalArrays/ga/blob/master/.github/workflows/github_actions.yml from the `master` branch, I would like to push these two update files (the workflow file itself and a script for running the tests) to the master branch.
Changelog:
* cleaned up the Intel MKL dependence in travis/run.sh
* github action workflow: cleaned up Intel steps
* github action workflow: explicitly set use_cmake Y/N for each step