### PR TITLE
Bug fix for block cyclic distributions

### DIFF
--- a/global/src/ga_iterator.h
+++ b/global/src/ga_iterator.h
@@ -31,6 +31,7 @@ typedef struct {
   Integer blk_size[MAXDIM];
   Integer proc_index[MAXDIM];
   Integer index[MAXDIM];
+  Integer no_data;
 } _iterator_hdl;
 
 #if 0

--- a/global/src/iterator.c
+++ b/global/src/iterator.c
@@ -728,11 +728,13 @@ int gai_iterator_next(_iterator_hdl *hdl, int *proc, Integer *plo[],
         *prem =  GA[handle].ptr[pinv]+l_offset*GA[handle].elemsize;
         *proc = pinv;
 
-        /* increment to next block */
+        /* evaluate new offset for block */
         itmp = 1;
         for (j=0; j<ndim; j++) {
           itmp *= bhi[j]-blo[j]+1;
         }
+        hdl->offset += itmp;
+        /* increment to next block */
         hdl->index[0] += GA[handle].nblock[0];
         for (j=0; j<ndim; j++) {
           if (hdl->index[j] >= GA[handle].num_blocks[j] && j < ndim-1) {

--- a/global/src/onesided.c
+++ b/global/src/onesided.c
@@ -1586,8 +1586,9 @@ void pnga_access_block_grid_ptr(Integer g_a, Integer *index, void* ptr, Integer 
   dims = GA[handle].dims;
   ndim = GA[handle].ndim;
   for (i=0; i<ndim; i++) {
-    if (index[i] < 0 || index[i] >= num_blocks[i])
-      pnga_error("block index outside allowed values",index[i]);
+    if (index[i] < 0 || index[i] >= num_blocks[i]) {
+      pnga_error("(grid_ptr) block index outside allowed values",index[i]);
+    }
   }
 
   /* Find strides of requested block */
@@ -1806,8 +1807,9 @@ void pnga_access_block_ptr(Integer g_a, Integer idx, void* ptr, Integer *ld)
   nblocks = GA[handle].block_total;
   ndim = GA[handle].ndim;
   index = idx;
-  if (index < 0 || index >= nblocks)
-    pnga_error("block index outside allowed values",index);
+  if (index < 0 || index >= nblocks) {
+    pnga_error("(block_ptr) block index outside allowed values",index);
+  }
 
   if (GA[handle].distr_type == BLOCK_CYCLIC) {
     offset = 0;
@@ -1988,8 +1990,9 @@ unsigned long    lref=0, lptr;
    
    /*p_handle = GA[handle].p_handle;*/
    iblock = idx;
-   if (iblock < 0 || iblock >= GA[handle].block_total)
-     pnga_error("block index outside allowed values",iblock);
+   if (iblock < 0 || iblock >= GA[handle].block_total) {
+     pnga_error("(block_idx) block index outside allowed values",iblock);
+   }
 
    pnga_access_block_ptr(g_a,iblock,&ptr,ld);
    /*


### PR DESCRIPTION
Errors in block cyclic distributions occur when the number of processors is high and the number of blocks is low. Some processors can end up with no data and this causes problems with the iterator.