### PR TITLE
MPI-PR: check for number of open files 

### DIFF
--- a/.github/workflows/github_actions.yml
+++ b/.github/workflows/github_actions.yml
@@ -67,6 +67,7 @@ jobs:
             armci_network: mpi-pr
             f77: ifort
             cc: icc
+            config_opts: LIBS=-lifcore
             oneapi: /Users/runner/apps/oneapi
           - os: ubuntu-20.04
             experimental: true 

--- a/.github/workflows/github_actions.yml
+++ b/.github/workflows/github_actions.yml
@@ -116,6 +116,7 @@ jobs:
             armci_network: mpi-ts
             f77: ifort
             cc: gcc
+            oneapi: /opt/intel/oneapi
         exclude:
           - armci_network: mpi-pr
             mpi_impl: openmpi

--- a/comex/src-mpi-pr/comex.c
+++ b/comex/src-mpi-pr/comex.c
@@ -179,7 +179,9 @@ static char *static_server_buffer = NULL;
 static int static_server_buffer_size = 0;
 static int eager_threshold = -1;
 static int max_message_size = -1;
+#if ENABLE_SYSV
 static int use_dev_shm = 1;
+#endif
 static int token_counter = 0;
 static int init_from_comm = 0;
 
@@ -7600,7 +7602,6 @@ STATIC void count_open_fds(void) {
 #ifdef DEBUGSHM
   if(nfiles % 1000 == 0) fprintf(stderr," %d: no. open files = %ld maxfiles = %ld\n", g_state.rank, nfiles, maxfiles);
 #endif
-  long mylimit = (maxfiles/100)*60;
     if(nfiles > (maxfiles/100)*60) {
       printf(" %d: running out of files; files = %ld  maxfiles = %ld\n", g_state.rank, nfiles, maxfiles);
 #if PAUSE_ON_ERROR

--- a/comex/src-mpi-pr/comex.c
+++ b/comex/src-mpi-pr/comex.c
@@ -7595,13 +7595,14 @@ STATIC void check_devshm(int fd, size_t size){
 STATIC void count_open_fds(void) {
   FILE *f = fopen("/proc/sys/fs/file-nr", "r");
 
-  int nfiles, unused, maxfiles;
-  fscanf(f, "%d %d %d", &nfiles, &unused, &maxfiles);
+  long nfiles, unused, maxfiles;
+  fscanf(f, "%ld %ld %ld", &nfiles, &unused, &maxfiles);
 #ifdef DEBUGSHM
-  if(nfiles % 1000 == 0) fprintf(stderr," %d: no. open files = %d maxfiles = %d\n", g_state.rank, nfiles, maxfiles);
+  if(nfiles % 1000 == 0) fprintf(stderr," %d: no. open files = %ld maxfiles = %ld\n", g_state.rank, nfiles, maxfiles);
 #endif
-  if(nfiles > (maxfiles*60/100)) {
-    printf(" %d: running out of files; files = %d maxfiles = %d\n", g_state.rank, nfiles, maxfiles);
+  long mylimit = (maxfiles/100)*60;
+    if(nfiles > (maxfiles/100)*60) {
+      printf(" %d: running out of files; files = %ld  maxfiles = %ld\n", g_state.rank, nfiles, maxfiles);
 #if PAUSE_ON_ERROR
     fprintf(stderr,"%d(%d): too many open files\n",
             g_state.rank,  getpid());


### PR DESCRIPTION
MPI-PR: check for number open files (generated on /dev/shm) 
Stop when the number of open files is greater than 60%  of the max value of open files (from `/proc/sys/fs/file-nr`)