### PR TITLE
disable use of BLAS in accumulate

### DIFF
--- a/cmx/src-common/acc.h
+++ b/cmx/src-common/acc.h
@@ -56,7 +56,7 @@ static inline void _scale(
             MUL_##WHICH(iterator[m], value[m], calc_scale);                 \
         }                                                                   \
     } else
-#if HAVE_BLAS
+#if 0 //HAVE_BLAS
     SCALE_BLAS(CMX_ACC_DBL, double, D)
     SCALE_BLAS(CMX_ACC_FLT, float, S)
     SCALE(REG, CMX_ACC_INT, int)

--- a/comex/src-common/acc.h
+++ b/comex/src-common/acc.h
@@ -77,7 +77,7 @@ static inline void _scale(
             MUL_##WHICH(iterator[m], value[m], calc_scale);                 \
         }                                                                   \
     } else
-#if HAVE_BLAS
+#if 0 // HAVE_BLAS
     SCALE_BLAS(COMEX_ACC_DBL, double, D)
     SCALE_BLAS(COMEX_ACC_FLT, float, S)
     SCALE(REG, COMEX_ACC_INT, int)


### PR DESCRIPTION
We observed a ~10% slowdown in some cases when this is enabled.

There is virtually no scenario on a modern computer where ?AXPY is faster than the same code in loops and many where it is slower.  The function call to a separate library in an ARMCI accumulate pollutes icache, for example.  The error checks in ?AXPY are not necessary in ARMCI either - those are pointless branches that don't exist in the loop implementation.