### PR TITLE
fix for comex on Solaris 

### DIFF
--- a/comex/src-mpi-mt/comex.c
+++ b/comex/src-mpi-mt/comex.c
@@ -77,7 +77,7 @@ typedef struct {
 typedef struct lock_link {
     struct lock_link *next;
     int rank;
-} lock_t;
+} comex_lock_t;
 
 
 typedef struct {

--- a/comex/src-mpi-pr/comex.c
+++ b/comex/src-mpi-pr/comex.c
@@ -11,6 +11,9 @@
 #include <semaphore.h>
 #include <signal.h>
 #include <stdio.h>
+#if HAVE_ERRNO_H
+#   include <errno.h>
+#endif
 #include <stdlib.h>
 #include <string.h>
 #include <strings.h>

--- a/comex/src-mpi-pr/comex.c
+++ b/comex/src-mpi-pr/comex.c
@@ -122,7 +122,7 @@ typedef struct {
 typedef struct lock_link {
     struct lock_link *next;
     int rank;
-} lock_t;
+} comex_lock_t;
 
 
 typedef struct {
@@ -164,7 +164,7 @@ typedef struct {
 /* static state */
 static int *num_mutexes = NULL;     /**< (all) how many mutexes on each process */
 static int **mutexes = NULL;        /**< (masters) value is rank of lock holder */
-static lock_t ***lq_heads = NULL;   /**< array of lock queues */
+static comex_lock_t ***lq_heads = NULL;   /**< array of lock queues */
 static char *sem_name = NULL;       /* local semaphore name */
 static sem_t **semaphores = NULL;   /* semaphores for locking within SMP node */
 static int initialized = 0;         /* for comex_initialized(), 0=false */
@@ -676,7 +676,7 @@ int _comex_init(MPI_Comm comm)
         mutexes = (int**)malloc(sizeof(int*) * g_state.size);
         COMEX_ASSERT(mutexes);
         /* create one lock queue for each proc for each mutex */
-        lq_heads = (lock_t***)malloc(sizeof(lock_t**) * g_state.size);
+        lq_heads = (comex_lock_t***)malloc(sizeof(comex_lock_t**) * g_state.size);
         COMEX_ASSERT(lq_heads);
         /* start the server */
         _progress_server();
@@ -4516,7 +4516,7 @@ STATIC void _mutex_create_handler(header_t *header, int proc)
 #endif
 
     mutexes[proc] = (int*)malloc(sizeof(int) * num);
-    lq_heads[proc] = (lock_t**)malloc(sizeof(lock_t*) * num);
+    lq_heads[proc] = (comex_lock_t**)malloc(sizeof(comex_lock_t*) * num);
     for (i=0; i<num; ++i) {
         mutexes[proc][i] = UNLOCKED;
         lq_heads[proc][i] = NULL;
@@ -4564,18 +4564,18 @@ STATIC void _lock_handler(header_t *header, int proc)
         server_send(&id, sizeof(int), proc);
     }
     else {
-        lock_t *lock = NULL;
+        comex_lock_t *lock = NULL;
 #if DEBUG
         fprintf(stderr, "[%d] _lq_push rank=%d req_by=%d id=%d\n",
                 g_state.rank, rank, proc, id);
 #endif
-        lock = malloc(sizeof(lock_t));
+        lock = malloc(sizeof(comex_lock_t));
         lock->next = NULL;
         lock->rank = proc;
 
         if (lq_heads[rank][id]) {
             /* insert at tail */
-            lock_t *lq = lq_heads[rank][id];
+            comex_lock_t *lq = lq_heads[rank][id];
             while (lq->next) {
                 lq = lq->next;
             }
@@ -4604,7 +4604,7 @@ STATIC void _unlock_handler(header_t *header, int proc)
     if (lq_heads[rank][id]) {
         /* a lock requester was queued */
         /* find the next lock request and update queue */
-        lock_t *lock = lq_heads[rank][id];
+        comex_lock_t *lock = lq_heads[rank][id];
         lq_heads[rank][id] = lq_heads[rank][id]->next;
         /* update lock */
         mutexes[rank][id] = lock->rank;

--- a/comex/src-mpi-pt/comex.c
+++ b/comex/src-mpi-pt/comex.c
@@ -6,6 +6,9 @@
 #include <fcntl.h>
 #include <semaphore.h>
 #include <stdio.h>
+#if HAVE_ERRNO_H
+#   include <errno.h>
+#endif
 #include <stdlib.h>
 #include <string.h>
 #include <strings.h>

--- a/comex/src-mpi-pt/comex.c
+++ b/comex/src-mpi-pt/comex.c
@@ -91,7 +91,7 @@ typedef struct {
 typedef struct lock_link {
     struct lock_link *next;
     int rank;
-} lock_t;
+} comex_lock_t;
 
 
 typedef struct {
@@ -132,7 +132,7 @@ typedef struct {
 /* static state */
 static int *num_mutexes = NULL;     /**< (all) how many mutexes on each process */
 static int **mutexes = NULL;        /**< (masters) value is rank of lock holder */
-static lock_t ***lq_heads = NULL;   /**< array of lock queues */
+static comex_lock_t ***lq_heads = NULL;   /**< array of lock queues */
 static char *sem_name = NULL;       /* local semaphore name */
 static sem_t **semaphores = NULL;   /* semaphores for locking within SMP node */
 static int initialized = 0;         /* for comex_initialized(), 0=false */
@@ -382,7 +382,7 @@ int _comex_init(MPI_Comm comm)
         mutexes = (int**)malloc(sizeof(int*) * g_state.size);
         COMEX_ASSERT(mutexes);
         /* create one lock queue for each proc for each mutex */
-        lq_heads = (lock_t***)malloc(sizeof(lock_t**) * g_state.size);
+        lq_heads = (comex_lock_t***)malloc(sizeof(comex_lock_t**) * g_state.size);
         COMEX_ASSERT(lq_heads);
         /* start the server */
         pthread_create(&progress_thread, NULL, _progress_server, NULL);
@@ -3306,7 +3306,7 @@ STATIC void _mutex_create_handler(header_t *header, int proc)
 #endif
 
     mutexes[proc] = (int*)malloc(sizeof(int) * num);
-    lq_heads[proc] = (lock_t**)malloc(sizeof(lock_t*) * num);
+    lq_heads[proc] = (comex_lock_t**)malloc(sizeof(comex_lock_t*) * num);
     for (i=0; i<num; ++i) {
         mutexes[proc][i] = UNLOCKED;
         lq_heads[proc][i] = NULL;
@@ -3354,18 +3354,18 @@ STATIC void _lock_handler(header_t *header, int proc)
         server_send(&id, sizeof(int), proc);
     }
     else {
-        lock_t *lock = NULL;
+        comex_lock_t *lock = NULL;
 #if DEBUG
         printf("[%d] _lq_push rank=%d req_by=%d id=%d\n",
                 g_state.rank, rank, proc, id);
 #endif
-        lock = malloc(sizeof(lock_t));
+        lock = malloc(sizeof(comex_lock_t));
         lock->next = NULL;
         lock->rank = proc;
 
         if (lq_heads[rank][id]) {
             /* insert at tail */
-            lock_t *lq = lq_heads[rank][id];
+            comex_lock_t *lq = lq_heads[rank][id];
             while (lq->next) {
                 lq = lq->next;
             }
@@ -3394,7 +3394,7 @@ STATIC void _unlock_handler(header_t *header, int proc)
     if (lq_heads[rank][id]) {
         /* a lock requester was queued */
         /* find the next lock request and update queue */
-        lock_t *lock = lq_heads[rank][id];
+        comex_lock_t *lock = lq_heads[rank][id];
         lq_heads[rank][id] = lq_heads[rank][id]->next;
         /* update lock */
         mutexes[rank][id] = lock->rank;

--- a/comex/src-mpi/comex.c
+++ b/comex/src-mpi/comex.c
@@ -1909,13 +1909,13 @@ static void _unlock_request_handler(header_t *header, int proc)
 
 static void _lq_push(int rank, int id, char *notify)
 {
-    lock_t *lock = NULL;
+    comex_lock_t *lock = NULL;
 
 #if DEBUG
     printf("[%d] _lq_push rank=%d id=%d\n", l_state.rank, rank, id);
 #endif
 
-    lock = _my_malloc(sizeof(lock_t));
+    lock = _my_malloc(sizeof(comex_lock_t));
     lock->next = NULL;
     lock->rank = rank;
     lock->id = id;
@@ -1943,9 +1943,9 @@ static void _lq_push(int rank, int id, char *notify)
 static int _lq_progress(void)
 {
     int needs_progress = 0;
-    lock_t *lock = NULL;
-    lock_t *new_lock_head = NULL;
-    lock_t *new_lock_tail = NULL;
+    comex_lock_t *lock = NULL;
+    comex_lock_t *new_lock_head = NULL;
+    comex_lock_t *new_lock_tail = NULL;
 
 #if DEBUG
     if (l_state.num_mutexes > 0) {
@@ -1960,7 +1960,7 @@ static int _lq_progress(void)
     lock = l_state.lq_head;
     while (lock) {
         if (l_state.mutexes[lock->id] < 0) {
-            lock_t *last = NULL;
+            comex_lock_t *last = NULL;
             header_t *header = NULL;
 
             l_state.mutexes[lock->id] = lock->rank;

--- a/comex/src-mpi/comex_impl.h
+++ b/comex/src-mpi/comex_impl.h
@@ -61,7 +61,7 @@ typedef struct lock_link {
     int rank;
     int id;
     void *notify_address;
-} lock_t;
+} comex_lock_t;
 
 typedef struct {
     MPI_Comm world_comm;
@@ -86,8 +86,8 @@ typedef struct {
     barrier_t *bq_tail;
 
     /* a queue for lock requests */
-    lock_t *lq_head;
-    lock_t *lq_tail;
+    comex_lock_t *lq_head;
+    comex_lock_t *lq_tail;
 
 } local_state;
 


### PR DESCRIPTION
* renamed `lock_t` as `comex_lock_t` because of conflict with Solaris system headers
* added `errno.h` since it is needed for `errno()` on SOLARIS
* tested on Solaris 11