### PR TITLE
Missing "external" statements in GA Fortran header

### DIFF
--- a/global/src/global.fh.in
+++ b/global/src/global.fh.in
@@ -194,6 +194,7 @@
       external ga_get_pgroup_size
       external ga_has_ghosts
       external ga_idot
+      external ga_initialize_comm
       external ga_initialized
       external ga_inquire_memory
       external ga_is_mirrored
@@ -275,6 +276,7 @@
       external nga_has_ghosts
       external nga_idot
       external nga_idot_patch
+      external nga_initialize_comm
       external nga_initialized
       external nga_inquire_memory
       external nga_is_mirrored


### PR DESCRIPTION
Dear Global Arrays team,

Thank you kindly for your work on maintaining global arrays and for the new releases this year, I appreciate all your hard work on this.

I noticed that version 5.9 enables the the new method `ga_initialize_comm` to set up GA attached to an existing MPI Comm, rather than assuming the use of `MPI_COMM_WORLD` and I have been trying to use this method in a Fortran code. So far I have been getting good results with this, but I noticed that unlike other GA functions a couple of the new methods have no `external` statement in the GA Fortran header file. Hence, the `external` statements have to be added by hand when the functions are used.

It looks like the testing of this feature has been using C rather than Fortran, so I thought I would feed this patch back upstream. Just let me know if I have misunderstood something -- I don't have much experience with Fortran header files myself.

The Fortran header file was updated with these methods in 326306d.


Thanks,
Tom