### PR TITLE
fix for memory leak in eaf

### DIFF
--- a/pario/eaf/eaf.c
+++ b/pario/eaf/eaf.c
@@ -479,6 +479,9 @@ int EAF_Delete(const char *fname)
 	 return EAF_ERR_UNLINK;
        }
        else
+	 if (file[j].fname != NULL) {
+	   free(file[j].fname);
+	 };
 	 file[j].fname= NULL;
            return EAF_OK;
        }else{


### PR DESCRIPTION
FIx for memory leak when `eaf_delete` is called without `eaf_close`

https://github.com/GlobalArrays/ga/issues/366