### PR TITLE
updates for autoconf

### DIFF
--- a/m4/ga_blas.m4
+++ b/m4/ga_blas.m4
@@ -107,8 +107,8 @@ blas_size=4
 blas_size_hack=no
 AC_ARG_WITH([blas],
     [AS_HELP_STRING([--with-blas[[=ARG]]],
-        [use external BLAS library; attempt to detect sizeof(INTEGER)])],
-    [blas_size_hack=yes])
+        [use external BLAS library compiled with sizeof(INTEGER)==4])],
+    [blas_size=4])
 AC_ARG_WITH([blas4],
     [AS_HELP_STRING([--with-blas4[[=ARG]]],
         [use external BLAS library compiled with sizeof(INTEGER)==4])],

--- a/m4/ga_scalapack.m4
+++ b/m4/ga_scalapack.m4
@@ -55,6 +55,10 @@ AC_ARG_WITH([scalapack],
     [AS_HELP_STRING([--with-scalapack=[[ARG]]],
         [use ScaLAPACK library compiled with sizeof(INTEGER)==4])],
     [scalapack_size=4])
+AC_ARG_WITH([scalapack4],
+    [AS_HELP_STRING([--with-scalapack4=[[ARG]]],
+        [use ScaLAPACK library compiled with sizeof(INTEGER)==4])],
+    [scalapack_size=4])
 AC_ARG_WITH([scalapack8],
     [AS_HELP_STRING([--with-scalapack8=[[ARG]]],
         [use ScaLAPACK library compiled with sizeof(INTEGER)==8])],


### PR DESCRIPTION
* removed automatic detection of blas integer size since it does not work (tested on ubuntu 22.04 with openblas and openblas64 ... in both case size=4 was detected)
* added --with-scalapack4 option for consistency with blas

