### PR TITLE
fix missing return value in sketch.c

### DIFF
--- a/global/src/sketch.c
+++ b/global/src/sketch.c
@@ -438,4 +438,5 @@ int pnga_sprs_array_num_nonzeros(Integer g_a)
     }
   }
   pnga_pgroup_gop(GA[handle].p_handle,type,&cnt,nprocs,"+");
+  return cnt;
 }


### PR DESCRIPTION
Addresses the issue https://github.com/GlobalArrays/ga/issues/374 